### PR TITLE
Issue263 fixed

### DIFF
--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -9,6 +9,8 @@ try
     if ~strcmpi(obj.PlotOptions.TreatAs, '_')
         if strcmpi(obj.PlotOptions.TreatAs, 'pie3')
             updatePie3(obj, dataIndex);
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'pcolor')
+            updatePColor(obj, dataIndex);
         end
         
     %-update plot based on plot call class-%

--- a/plotly/plotlyfig_aux/handlegraphics/updatePColor.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updatePColor.m
@@ -31,15 +31,28 @@ obj.data{patchIndex}.type = 'surface';
 
 %-------------------------------------------------------------------------%
 
-%-handle vertices-%
-xdata = []; ydata = []; zdata = []; cdata = [];
+%-format data-%
+XData = pcolor_data.XData;
+YData = pcolor_data.YData;
+ZData = pcolor_data.ZData;
+CData = pcolor_data.CData;
 
-for n = 1:size(pcolor_data.XData, 2)-1
-    for m = 1:size(pcolor_data.XData, 1)-1
-        xdata = [xdata pcolor_data.XData(m:m+1, n:n+1) NaN(2,1)];
-        ydata = [ydata pcolor_data.YData(m:m+1, n:n+1) NaN(2,1)];
-        zdata = [zdata pcolor_data.ZData(m:m+1, n:n+1) NaN(2,1)];
-        cdata = [cdata ones(2,3)*pcolor_data.CData(m, n)];
+xdata = zeros(size(XData, 1)-1*2, size(XData, 2)-1*2); 
+ydata = zeros(size(XData, 1)-1*2, size(XData, 2)-1*2); 
+zdata = zeros(size(XData, 1)-1*2, size(XData, 2)-1*2); 
+cdata = zeros(size(XData, 1)-1*2, size(XData, 2)-1*2); 
+
+for n = 1:size(XData, 2)-1
+    for m = 1:size(XData, 1)-1
+        
+        % get indices
+        n1 = 2*(n-1)+1; m1 = 2*(m-1)+1;
+        
+        % get surface mesh
+        xdata(m1:m1+1,n1:n1+1) = XData(m:m+1, n:n+1);
+        ydata(m1:m1+1,n1:n1+1) = YData(m:m+1, n:n+1);
+        zdata(m1:m1+1,n1:n1+1) = ZData(m:m+1, n:n+1);
+        cdata(m1:m1+1,n1:n1+1) = ones(2,2)*CData(m, n);
     end
 end
 
@@ -60,7 +73,7 @@ obj.data{patchIndex}.z = zdata;
 
 %-------------------------------------------------------------------------%
 
-%-colorscale to map-%
+%-coloring-%
 cmap = figure_data.Colormap;
 len = length(cmap)-1;
 
@@ -71,6 +84,8 @@ end
 
 obj.data{patchIndex}.surfacecolor = cdata;
 obj.data{patchIndex}.showscale = false;
+obj.data{patchIndex}.cmin = min(CData(:));
+obj.data{patchIndex}.cmax = max(CData(:));
 
 %-------------------------------------------------------------------------%
 
@@ -92,6 +107,7 @@ obj.layout.scene.camera.eye.z = 14;
 obj.layout.scene.xaxis.showticklabels = true;
 obj.layout.scene.xaxis.zeroline = false;
 obj.layout.scene.xaxis.showgrid = false;
+obj.layout.scene.xaxis.title = '';
 
 %-------------------------------------------------------------------------%
 
@@ -99,6 +115,7 @@ obj.layout.scene.xaxis.showgrid = false;
 obj.layout.scene.yaxis.zeroline = false;
 obj.layout.scene.yaxis.showgrid = false;
 obj.layout.scene.yaxis.showticklabels = true;
+obj.layout.scene.yaxis.title = '';
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updatePColor.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updatePColor.m
@@ -1,0 +1,130 @@
+function obj = updatePColor(obj, patchIndex)
+
+%-AXIS INDEX-%
+axIndex = obj.getAxisIndex(obj.State.Plot(patchIndex).AssociatedAxis);
+
+%-PCOLOR DATA STRUCTURE- %
+pcolor_data = get(obj.State.Plot(patchIndex).Handle);
+figure_data = get(obj.State.Figure.Handle);
+
+%-CHECK FOR MULTIPLE AXES-%
+[xsource, ysource] = findSourceAxis(obj,axIndex);
+
+%-AXIS DATA-%
+eval(['xaxis = obj.layout.xaxis' num2str(xsource) ';']);
+eval(['yaxis = obj.layout.yaxis' num2str(ysource) ';']);
+
+%-------------------------------------------------------------------------%
+
+%-pcolor xaxis-%
+obj.data{patchIndex}.xaxis = ['x' num2str(xsource)];
+
+%-------------------------------------------------------------------------%
+
+%-pcolor yaxis-%
+obj.data{patchIndex}.yaxis = ['y' num2str(ysource)];
+
+%-------------------------------------------------------------------------%
+
+%-plot type: surface-%
+obj.data{patchIndex}.type = 'surface';
+
+%-------------------------------------------------------------------------%
+
+%-handle vertices-%
+xdata = []; ydata = []; zdata = []; cdata = [];
+
+for n = 1:size(pcolor_data.XData, 2)-1
+    for m = 1:size(pcolor_data.XData, 1)-1
+        xdata = [xdata pcolor_data.XData(m:m+1, n:n+1) NaN(2,1)];
+        ydata = [ydata pcolor_data.YData(m:m+1, n:n+1) NaN(2,1)];
+        zdata = [zdata pcolor_data.ZData(m:m+1, n:n+1) NaN(2,1)];
+        cdata = [cdata ones(2,3)*pcolor_data.CData(m, n)];
+    end
+end
+
+%-------------------------------------------------------------------------%
+
+%-x-data-%
+obj.data{patchIndex}.x = xdata; 
+
+%-------------------------------------------------------------------------%
+
+%-y-data-%
+obj.data{patchIndex}.y = ydata; 
+
+%-------------------------------------------------------------------------%
+
+%-z-data-%
+obj.data{patchIndex}.z = zdata; 
+
+%-------------------------------------------------------------------------%
+
+%-colorscale to map-%
+cmap = figure_data.Colormap;
+len = length(cmap)-1;
+
+for c = 1: length(cmap)
+    col = 255 * cmap(c, :);
+    obj.data{patchIndex}.colorscale{c} = { (c-1)/len , ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'  ]  };
+end
+
+obj.data{patchIndex}.surfacecolor = cdata;
+obj.data{patchIndex}.showscale = false;
+
+%-------------------------------------------------------------------------%
+
+%-aspectratio-%
+obj.layout.scene.aspectratio.x = 12;
+obj.layout.scene.aspectratio.y = 10;
+obj.layout.scene.aspectratio.z = 0.0001;
+
+%-------------------------------------------------------------------------%
+
+%-camera.eye-%
+obj.layout.scene.camera.eye.x = 0;
+obj.layout.scene.camera.eye.y = -0.5;
+obj.layout.scene.camera.eye.z = 14;
+
+%-------------------------------------------------------------------------%
+
+%-hide axis-x-%
+obj.layout.scene.xaxis.showticklabels = true;
+obj.layout.scene.xaxis.zeroline = false;
+obj.layout.scene.xaxis.showgrid = false;
+
+%-------------------------------------------------------------------------%
+
+%-hide axis-y-%
+obj.layout.scene.yaxis.zeroline = false;
+obj.layout.scene.yaxis.showgrid = false;
+obj.layout.scene.yaxis.showticklabels = true;
+
+%-------------------------------------------------------------------------%
+
+%-hide axis-z-%
+obj.layout.scene.zaxis.title = '';
+obj.layout.scene.zaxis.autotick = false;
+obj.layout.scene.zaxis.zeroline = false;
+obj.layout.scene.zaxis.showline = false;
+obj.layout.scene.zaxis.showticklabels = false;
+obj.layout.scene.zaxis.showgrid = false;
+
+%-------------------------------------------------------------------------%
+
+%-patch showlegend-%
+leg = get(pcolor_data.Annotation);
+legInfo = get(leg.LegendInformation);
+
+switch legInfo.IconDisplayStyle
+    case 'on'
+        showleg = true;
+    case 'off'
+        showleg = false;
+end
+
+obj.data{patchIndex}.showlegend = showleg;
+
+%-------------------------------------------------------------------------%
+
+end


### PR DESCRIPTION
This PR fix the issue #263. This issue is related to `pcolor` similar to issue #265. Then working with this issue I was careful to ensure that modifications works for both issues (both #263 and for #265)

codes to test:

```
X = [.5 2 6; .5 2 6; .5 2 6];
Y = X';
C = [3 4 5; 1 2 5; 5 5 5];
pcolor(X,Y,C)

fig2plotly(gcf, 'offline', 0, 'TreatAs', 'pcolor');
```

```
[X,Y] = meshgrid(-3:6/17:3);
XX = 2*X.*Y;
YY = X.^2 - Y.^2;
colorscale = [1:18; 18:-1:1];
C = repmat(colorscale,9,1);
pcolor(XX,YY,C);

fig2plotly(gcf, 'offline', 0, 'TreatAs', 'pcolor');
```

Here the results

<img width="1218" alt="Screen Shot 2021-08-14 at 9 35 07 AM" src="https://user-images.githubusercontent.com/56391490/129448300-1663faca-4053-4df7-85e7-e4e6dc0bb6f9.png">
<img width="1241" alt="Screen Shot 2021-08-14 at 9 35 26 AM" src="https://user-images.githubusercontent.com/56391490/129448303-479864d4-f9af-4138-8623-0d0ad34ce499.png">
<img width="1364" alt="Screen Shot 2021-08-14 at 9 36 12 AM" src="https://user-images.githubusercontent.com/56391490/129448304-a1cf79e5-b78e-4c6f-bf55-700022221637.png">
<img width="1354" alt="Screen Shot 2021-08-14 at 9 36 35 AM" src="https://user-images.githubusercontent.com/56391490/129448306-0224b42f-2cd3-4e7a-a132-78cdeffafed2.png">
