### PR TITLE
Issue194 fixed

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -62,6 +62,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.StripMargins = false;
             obj.PlotOptions.TreatAs = '_';
             obj.PlotOptions.Image3D = false;
+            obj.PlotOptions.ContourProjection = false;
             
             % offline options
             obj.PlotOptions.Offline = true;

--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -63,6 +63,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.TreatAs = '_';
             obj.PlotOptions.Image3D = false;
             obj.PlotOptions.ContourProjection = false;
+            obj.PlotOptions.AxisEqual = false;
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -204,6 +205,9 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'TreatAs'))
                             obj.PlotOptions.TreatAs = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'AxisEqual'))
+                            obj.PlotOptions.AxisEqual = varargin{a+1};
                         end
                     end
             end
@@ -670,8 +674,14 @@ classdef plotlyfig < handle
             
             % update annotations
             for n = 1:obj.State.Figure.NumTexts
+                try 
+                    plotclass = obj.State.Plot(n).Class;
+                catch
+                    plotclass = ' ';
+                end
+                
                 try
-                    if ~strcmpi(obj.State.Plot(dataIndex).Class, 'heatmap')
+                    if ~strcmpi(plotclass, 'heatmap')
                         updateAnnotation(obj,n);
                     else
                         obj.PlotOptions.CleanFeedTitle = false;

--- a/plotly/plotlyfig_aux/core/updateAxis.m
+++ b/plotly/plotlyfig_aux/core/updateAxis.m
@@ -62,13 +62,22 @@ yaxis = extractAxisData(obj,axis_data,'Y');
 
 %-------------------------------------------------------------------------%
 
+if obj.PlotOptions.AxisEqual
+    wh = min(axis_data.Position(3:4));
+    w = wh;
+    h = wh; 
+else
+    w = axis_data.Position(3);
+    h = axis_data.Position(4);
+end
+
 %-xaxis domain-%
-xaxis.domain = min([axis_data.Position(1) axis_data.Position(1)+axis_data.Position(3)],1);
+xaxis.domain = min([axis_data.Position(1) axis_data.Position(1) + w],1);
 
 %-------------------------------------------------------------------------%
 
 %-yaxis domain-%
-yaxis.domain = min([axis_data.Position(2) axis_data.Position(2)+axis_data.Position(4)],1);
+yaxis.domain = min([axis_data.Position(2) axis_data.Position(2) + h],1);
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -70,7 +70,11 @@ try
             case 'baseline'
                 updateBaseline(obj, dataIndex);
             case {'contourgroup','contour'}
-                updateContourgroup(obj,dataIndex);
+                if ~obj.PlotOptions.ContourProjection
+                    updateContourgroup(obj,dataIndex);
+                else
+                    updateContourProjection(obj,dataIndex);
+                end
             case 'functioncontour'
                 updateFunctionContour(obj,dataIndex);
             case 'errorbar'

--- a/plotly/plotlyfig_aux/core/updateFigure.m
+++ b/plotly/plotlyfig_aux/core/updateFigure.m
@@ -68,13 +68,22 @@ obj.layout.margin.t = 0;
 
 %-------------------------------------------------------------------------%
 
+if obj.PlotOptions.AxisEqual
+    wh = min(figure_data.Position(3:4));
+    w = wh;
+    h = wh; 
+else
+    w = figure_data.Position(3);
+    h = figure_data.Position(4);
+end
+    
 %-figure width-%
-obj.layout.width = figure_data.Position(3)*obj.PlotlyDefaults.FigureIncreaseFactor;
+obj.layout.width = w * obj.PlotlyDefaults.FigureIncreaseFactor;
 
 %-------------------------------------------------------------------------%
 
 %-figure height-%
-obj.layout.height = figure_data.Position(4)*obj.PlotlyDefaults.FigureIncreaseFactor;
+obj.layout.height = h * obj.PlotlyDefaults.FigureIncreaseFactor;
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateContourProjection.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateContourProjection.m
@@ -1,0 +1,230 @@
+function obj = updateContourProjection(obj,contourIndex)
+
+%-FIGURE DATA STRUCTURE-%
+figure_data = get(obj.State.Figure.Handle);
+
+%-AXIS INDEX-%
+axIndex = obj.getAxisIndex(obj.State.Plot(contourIndex).AssociatedAxis);
+
+%-AXIS DATA STRUCTURE-%
+axis_data = get(obj.State.Plot(contourIndex).AssociatedAxis);
+
+%-PLOT DATA STRUCTURE- %
+contour_data = get(obj.State.Plot(contourIndex).Handle)
+
+%-CHECK FOR MULTIPLE AXES-%
+[xsource, ysource] = findSourceAxis(obj,axIndex);
+
+%-AXIS DATA-%
+eval(['xaxis = obj.layout.xaxis' num2str(xsource) ';']);
+eval(['yaxis = obj.layout.yaxis' num2str(ysource) ';']);
+
+%-------------------------------------------------------------------------%
+
+%-contour xaxis-%
+obj.data{contourIndex}.xaxis = ['x' num2str(xsource)];
+
+%-------------------------------------------------------------------------%
+
+%-contour yaxis-%
+obj.data{contourIndex}.yaxis = ['y' num2str(ysource)];
+
+%-------------------------------------------------------------------------%
+
+%-contour name-%
+obj.data{contourIndex}.name = contour_data.DisplayName;
+
+%-------------------------------------------------------------------------%
+
+%-setting the plot-%
+xdata = contour_data.XData;
+ydata = contour_data.YData;
+zdata = contour_data.ZData;
+
+if isvector(zdata)
+    
+    %-contour type-%
+    obj.data{contourIndex}.type = 'contour';
+    
+    %-contour x data-%
+    if ~isvector(x)
+        obj.data{contourIndex}.xdata = xdata(1,:);
+    else
+        obj.data{contourIndex}.xdata = xdata;
+    end
+
+    %-contour y data-%
+    if ~isvector(y)
+        obj.data{contourIndex}.ydata = ydata';
+    else
+        obj.data{contourIndex}.ydata = ydata';
+    end
+    
+    %-contour z data-%
+    obj.data{contourIndex}.z = zdata;
+    
+else
+    
+    %-contour type-%
+    obj.data{contourIndex}.type = 'surface';
+    
+    %-contour x and y data
+%     [xmesh, ymesh] = meshgrid(xdata, ydata);
+    obj.data{contourIndex}.x = xdata;
+    obj.data{contourIndex}.y = ydata;
+    
+    %-contour z data-%
+    obj.data{contourIndex}.z = zdata;%-2*ones(size(zdata));
+    
+    %-setting for contour lines z-direction-%
+    obj.data{contourIndex}.contours.z.start = contour_data.LevelList(1);
+    obj.data{contourIndex}.contours.z.end = contour_data.LevelList(end);
+    obj.data{contourIndex}.contours.z.size = contour_data.LevelStep;
+    obj.data{contourIndex}.contours.z.show = true;
+    obj.data{contourIndex}.contours.z.usecolormap = true;
+    obj.data{contourIndex}.hidesurface = true;
+    obj.data{contourIndex}.surfacecolor = zdata;
+    
+    obj.data{contourIndex}.contours.z.project.x = true;
+    obj.data{contourIndex}.contours.z.project.y = true;
+    obj.data{contourIndex}.contours.z.project.z = true;
+    
+end
+
+%-------------------------------------------------------------------------%
+
+%-contour x type-%
+
+obj.data{contourIndex}.xtype = 'array';
+
+%-------------------------------------------------------------------------%
+
+%-contour y type-%
+
+obj.data{contourIndex}.ytype = 'array';
+
+%-------------------------------------------------------------------------%
+
+%-contour visible-%
+
+obj.data{contourIndex}.visible = strcmp(contour_data.Visible,'on');
+
+%-------------------------------------------------------------------------%
+
+%-contour showscale-%
+obj.data{contourIndex}.showscale = false;
+
+%-------------------------------------------------------------------------%
+
+%-zauto-%
+obj.data{contourIndex}.zauto = false;
+
+%-------------------------------------------------------------------------%
+
+%-zmin-%
+obj.data{contourIndex}.zmin = axis_data.CLim(1);
+
+%-------------------------------------------------------------------------%
+
+%-zmax-%
+obj.data{contourIndex}.zmax = axis_data.CLim(2);
+
+%-------------------------------------------------------------------------%
+
+%-colorscale (ASSUMES PATCH CDATAMAP IS 'SCALED')-%
+colormap = figure_data.Colormap;
+
+for c = 1:size((colormap),1)
+    col =  255*(colormap(c,:));
+    obj.data{contourIndex}.colorscale{c} = {(c-1)/(size(colormap,1)-1), ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')']};
+end
+
+%-------------------------------------------------------------------------%
+
+%-contour reverse scale-%
+obj.data{contourIndex}.reversescale = false;
+
+%-------------------------------------------------------------------------%
+
+%-autocontour-%
+obj.data{contourIndex}.autocontour = false;
+
+%-------------------------------------------------------------------------%
+
+%-contour contours-%
+
+%-coloring-%
+switch contour_data.Fill
+    case 'off'
+        obj.data{contourIndex}.contours.coloring = 'lines';
+    case 'on'
+        obj.data{contourIndex}.contours.coloring = 'fill';
+end
+
+%-start-%
+obj.data{contourIndex}.contours.start = contour_data.TextList(1);
+
+%-end-%
+obj.data{contourIndex}.contours.end = contour_data.TextList(end);
+
+%-step-%
+obj.data{contourIndex}.contours.size = diff(contour_data.TextList(1:2));
+
+%-------------------------------------------------------------------------%
+
+if(~strcmp(contour_data.LineStyle,'none'))
+    
+    %-contour line colour-%
+    if isnumeric(contour_data.LineColor)
+        col = 255*contour_data.LineColor;
+        obj.data{contourIndex}.line.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+    else
+        obj.data{contourIndex}.line.color = 'rgba(0,0,0,0)';
+    end
+    
+    %-contour line width-%
+    obj.data{contourIndex}.line.width = contour_data.LineWidth;
+    
+    %-contour line dash-%
+    switch contour_data.LineStyle
+        case '-'
+            LineStyle = 'solid';
+        case '--'
+            LineStyle = 'dash';
+        case ':'
+            LineStyle = 'dot';
+        case '-.'
+            LineStyle = 'dashdot';
+    end
+    
+    obj.data{contourIndex}.line.dash = LineStyle;
+    
+    %-contour smoothing-%
+    obj.data{contourIndex}.line.smoothing = 0;
+    
+else
+    
+    %-contours showlines-%
+    obj.data{contourIndex}.contours.showlines = false;
+    
+end
+
+%-------------------------------------------------------------------------%
+
+%-contour showlegend-%
+
+leg = get(contour_data.Annotation);
+legInfo = get(leg.LegendInformation);
+
+switch legInfo.IconDisplayStyle
+    case 'on'
+        showleg = true;
+    case 'off'
+        showleg = false;
+end
+
+obj.data{contourIndex}.showlegend = showleg;
+
+%-------------------------------------------------------------------------%
+
+end

--- a/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
@@ -108,34 +108,51 @@ else
     obj.data{contourIndex}.type = 'surface';
     
     %-contour x and y data
-    [xmesh, ymesh] = meshgrid(xdata, ydata);
-    obj.data{contourIndex}.x = xmesh;
-    obj.data{contourIndex}.y = ymesh;
+    if isvector(xdata)
+        [xdata, ydata] = meshgrid(xdata, ydata);
+    end
+    obj.data{contourIndex}.x = xdata;
+    obj.data{contourIndex}.y = ydata;
     
     %-contour z data-%
     obj.data{contourIndex}.z = zdata;
     
     %-setting for contour lines z-direction-%
-    obj.data{contourIndex}.contours.z.start = contour_data.LevelList(1);
-    obj.data{contourIndex}.contours.z.end = contour_data.LevelList(end);
-    obj.data{contourIndex}.contours.z.size = contour_data.LevelStep;
+    if length(contour_data.LevelList) > 1
+        zstart = contour_data.LevelList(1);
+        zend = contour_data.LevelList(end);
+        zsize = mean(diff(contour_data.LevelList));
+    else
+        zstart = contour_data.LevelList(1) - 1e-3;
+        zend = contour_data.LevelList(end) + 1e-3;
+        zsize = 2e-3;
+    end
+    l = 30;
+    obj.data{contourIndex}.contours.z.start = zstart;
+    obj.data{contourIndex}.contours.z.end = zend;
+    obj.data{contourIndex}.contours.z.size = zsize;
     obj.data{contourIndex}.contours.z.show = true;
     obj.data{contourIndex}.contours.z.usecolormap = true;
+    obj.data{contourIndex}.contours.z.width = contour_data.LineWidth;
     obj.data{contourIndex}.hidesurface = true;
     
 end
 
 %-------------------------------------------------------------------------%
 
-%-contour x type-%
+if isvector(zdata)
+    
+    %-contour x type-%
 
-obj.data{contourIndex}.xtype = 'array';
+    obj.data{contourIndex}.xtype = 'array';
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-contour y type-%
+    %-contour y type-%
 
-obj.data{contourIndex}.ytype = 'array';
+    obj.data{contourIndex}.ytype = 'array';
+    
+end
 
 %-------------------------------------------------------------------------%
 
@@ -150,18 +167,20 @@ obj.data{contourIndex}.showscale = false;
 
 %-------------------------------------------------------------------------%
 
-%-zauto-%
-obj.data{contourIndex}.zauto = false;
+if isvector(zdata)
+    %-zauto-%
+    obj.data{contourIndex}.zauto = false;
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-zmin-%
-obj.data{contourIndex}.zmin = axis_data.CLim(1);
+    %-zmin-%
+    obj.data{contourIndex}.zmin = axis_data.CLim(1);
 
-%-------------------------------------------------------------------------%
+    %-------------------------------------------------------------------------%
 
-%-zmax-%
-obj.data{contourIndex}.zmax = axis_data.CLim(2);
+    %-zmax-%
+    obj.data{contourIndex}.zmax = axis_data.CLim(2);
+end
 
 %-------------------------------------------------------------------------%
 
@@ -180,67 +199,77 @@ obj.data{contourIndex}.reversescale = false;
 
 %-------------------------------------------------------------------------%
 
-%-autocontour-%
-obj.data{contourIndex}.autocontour = false;
-
-%-------------------------------------------------------------------------%
-
-%-contour contours-%
-
-%-coloring-%
-switch contour_data.Fill
-    case 'off'
-        obj.data{contourIndex}.contours.coloring = 'lines';
-    case 'on'
-        obj.data{contourIndex}.contours.coloring = 'fill';
+if isvector(zdata)
+    
+    %-autocontour-%
+    obj.data{contourIndex}.autocontour = false;
+    
 end
 
-%-start-%
-obj.data{contourIndex}.contours.start = contour_data.TextList(1);
+%-------------------------------------------------------------------------%
 
-%-end-%
-obj.data{contourIndex}.contours.end = contour_data.TextList(end);
+if isvector(zdata)
+    
+    %-contour contours-%
 
-%-step-%
-obj.data{contourIndex}.contours.size = diff(contour_data.TextList(1:2));
+    %-coloring-%
+    switch contour_data.Fill
+        case 'off'
+            obj.data{contourIndex}.contours.coloring = 'lines';
+        case 'on'
+            obj.data{contourIndex}.contours.coloring = 'fill';
+    end
+
+    %-start-%
+    obj.data{contourIndex}.contours.start = contour_data.TextList(1);
+
+    %-end-%
+    obj.data{contourIndex}.contours.end = contour_data.TextList(end);
+
+    %-step-%
+    obj.data{contourIndex}.contours.size = diff(contour_data.TextList(1:2));
+    
+end
 
 %-------------------------------------------------------------------------%
 
-if(~strcmp(contour_data.LineStyle,'none'))
-    
-    %-contour line colour-%
-    if isnumeric(contour_data.LineColor)
-        col = 255*contour_data.LineColor;
-        obj.data{contourIndex}.line.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+if isvector(zdata)
+    if(~strcmp(contour_data.LineStyle,'none'))
+
+        %-contour line colour-%
+        if isnumeric(contour_data.LineColor)
+            col = 255*contour_data.LineColor;
+            obj.data{contourIndex}.line.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+        else
+            obj.data{contourIndex}.line.color = 'rgba(0,0,0,0)';
+        end
+
+        %-contour line width-%
+        obj.data{contourIndex}.line.width = contour_data.LineWidth;
+
+        %-contour line dash-%
+        switch contour_data.LineStyle
+            case '-'
+                LineStyle = 'solid';
+            case '--'
+                LineStyle = 'dash';
+            case ':'
+                LineStyle = 'dot';
+            case '-.'
+                LineStyle = 'dashdot';
+        end
+
+        obj.data{contourIndex}.line.dash = LineStyle;
+
+        %-contour smoothing-%
+        obj.data{contourIndex}.line.smoothing = 0;
+
     else
-        obj.data{contourIndex}.line.color = 'rgba(0,0,0,0)';
+
+        %-contours showlines-%
+        obj.data{contourIndex}.contours.showlines = false;
+
     end
-    
-    %-contour line width-%
-    obj.data{contourIndex}.line.width = contour_data.LineWidth;
-    
-    %-contour line dash-%
-    switch contour_data.LineStyle
-        case '-'
-            LineStyle = 'solid';
-        case '--'
-            LineStyle = 'dash';
-        case ':'
-            LineStyle = 'dot';
-        case '-.'
-            LineStyle = 'dashdot';
-    end
-    
-    obj.data{contourIndex}.line.dash = LineStyle;
-    
-    %-contour smoothing-%
-    obj.data{contourIndex}.line.smoothing = 0;
-    
-else
-    
-    %-contours showlines-%
-    obj.data{contourIndex}.contours.showlines = false;
-    
 end
 
 %-------------------------------------------------------------------------%

--- a/plotly/plotlyfig_aux/handlegraphics/updateSurfaceplot.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateSurfaceplot.m
@@ -64,13 +64,16 @@ if any(nonzeros(image_data.ZData))
     %-if image comes would a 3D plot-%
     obj.PlotOptions.Image3D = true;
     
+    %-if contour comes would a ContourProjection-%
+    obj.PlotOptions.ContourProjection = true;
+    
     %---------------------------------------------------------------------%
 
     %- setting grid mesh by default -%
     % x-direction
     xmin = min(x(:));
     xmax = max(x(:));
-    xsize = (xmax - xmin) / (size(x, 2)); 
+    xsize = (xmax - xmin) / (size(x, 2)-1); 
     obj.data{surfaceIndex}.contours.x.start = xmin;
     obj.data{surfaceIndex}.contours.x.end = xmax;
     obj.data{surfaceIndex}.contours.x.size = xsize;
@@ -79,7 +82,7 @@ if any(nonzeros(image_data.ZData))
     % y-direction
     ymin = min(y(:));
     ymax = max(y(:));
-    ysize = (ymax - ymin) / (size(y, 1));
+    ysize = (ymax - ymin) / (size(y, 1)-1);
     obj.data{surfaceIndex}.contours.y.start = ymin;
     obj.data{surfaceIndex}.contours.y.end = ymax;
     obj.data{surfaceIndex}.contours.y.size = ysize;


### PR DESCRIPTION
This PR fix the issue #194 

For this I proposed a new plot option to control axis size called `AxisEqual`

code to test:

```
close all, clc
X = [1 3 0.5 2.5 2];
pie(X)
fig2plotly(gcf, 'offline', 0, 'AxisEqual', true);
```

Using before code results are as bellow

<img width="1143" alt="Screen Shot 2021-08-18 at 8 37 52 PM" src="https://user-images.githubusercontent.com/56391490/129990226-64168442-3ec7-4753-a3df-235e4d0da774.png">
<img width="1210" alt="Screen Shot 2021-08-18 at 8 38 58 PM" src="https://user-images.githubusercontent.com/56391490/129990236-efb54e60-d673-43c7-bb04-70dcb4ae2db5.png">


If `'AxisEqual'` is not set or is set to `false` then the result is as bellow

<img width="1284" alt="Screen Shot 2021-08-18 at 8 43 13 PM" src="https://user-images.githubusercontent.com/56391490/129990283-18637bca-a4a8-4ed8-afaa-87724bf13271.png">


