### PR TITLE
Contour3issues ratio aspect camera eye

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -64,6 +64,8 @@ classdef plotlyfig < handle
             obj.PlotOptions.Image3D = false;
             obj.PlotOptions.ContourProjection = false;
             obj.PlotOptions.AxisEqual = false;
+            obj.PlotOptions.AspectRatio = [];
+            obj.PlotOptions.CameraEye = [];
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -208,6 +210,12 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'AxisEqual'))
                             obj.PlotOptions.AxisEqual = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'AspectRatio'))
+                            obj.PlotOptions.AspectRatio = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'CameraEye'))
+                            obj.PlotOptions.CameraEye = varargin{a+1};
                         end
                     end
             end

--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -63,6 +63,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.TreatAs = '_';
             obj.PlotOptions.Image3D = false;
             obj.PlotOptions.ContourProjection = false;
+            obj.PlotOptions.AxisEqual = false;
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -204,6 +205,9 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'TreatAs'))
                             obj.PlotOptions.TreatAs = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'AxisEqual'))
+                            obj.PlotOptions.AxisEqual = varargin{a+1};
                         end
                     end
             end
@@ -670,8 +674,14 @@ classdef plotlyfig < handle
             
             % update annotations
             for n = 1:obj.State.Figure.NumTexts
+                try 
+                    plotclass = obj.State.Plot(n).Class;
+                catch
+                    plotclass = ' ';
+                end
+                
                 try
-                    if ~strcmpi(obj.State.Plot(dataIndex).Class, 'heatmap')
+                    if ~strcmpi(plotclass, 'heatmap')
                         updateAnnotation(obj,n);
                     else
                         obj.PlotOptions.CleanFeedTitle = false;

--- a/plotly/plotlyfig_aux/core/updateAxis.m
+++ b/plotly/plotlyfig_aux/core/updateAxis.m
@@ -62,13 +62,22 @@ yaxis = extractAxisData(obj,axis_data,'Y');
 
 %-------------------------------------------------------------------------%
 
+if obj.PlotOptions.AxisEqual
+    wh = min(axis_data.Position(3:4));
+    w = wh;
+    h = wh; 
+else
+    w = axis_data.Position(3);
+    h = axis_data.Position(4);
+end
+
 %-xaxis domain-%
-xaxis.domain = min([axis_data.Position(1) axis_data.Position(1)+axis_data.Position(3)],1);
+xaxis.domain = min([axis_data.Position(1) axis_data.Position(1) + w],1);
 
 %-------------------------------------------------------------------------%
 
 %-yaxis domain-%
-yaxis.domain = min([axis_data.Position(2) axis_data.Position(2)+axis_data.Position(4)],1);
+yaxis.domain = min([axis_data.Position(2) axis_data.Position(2) + h],1);
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/core/updateFigure.m
+++ b/plotly/plotlyfig_aux/core/updateFigure.m
@@ -68,13 +68,22 @@ obj.layout.margin.t = 0;
 
 %-------------------------------------------------------------------------%
 
+if obj.PlotOptions.AxisEqual
+    wh = min(figure_data.Position(3:4));
+    w = wh;
+    h = wh; 
+else
+    w = figure_data.Position(3);
+    h = figure_data.Position(4);
+end
+    
 %-figure width-%
-obj.layout.width = figure_data.Position(3)*obj.PlotlyDefaults.FigureIncreaseFactor;
+obj.layout.width = w * obj.PlotlyDefaults.FigureIncreaseFactor;
 
 %-------------------------------------------------------------------------%
 
 %-figure height-%
-obj.layout.height = figure_data.Position(4)*obj.PlotlyDefaults.FigureIncreaseFactor;
+obj.layout.height = h * obj.PlotlyDefaults.FigureIncreaseFactor;
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateContourgroup.m
@@ -82,8 +82,12 @@ zdata = contour_data.ZData;
 
 if isvector(zdata)
     
+    %---------------------------------------------------------------------%
+    
     %-contour type-%
     obj.data{contourIndex}.type = 'contour';
+    
+    %---------------------------------------------------------------------%
     
     %-contour x data-%
     if ~isvector(x)
@@ -91,7 +95,9 @@ if isvector(zdata)
     else
         obj.data{contourIndex}.xdata = xdata;
     end
-
+    
+    %---------------------------------------------------------------------%
+    
     %-contour y data-%
     if ~isvector(y)
         obj.data{contourIndex}.ydata = ydata';
@@ -99,116 +105,44 @@ if isvector(zdata)
         obj.data{contourIndex}.ydata = ydata';
     end
     
-    %-contour z data-%
-    obj.data{contourIndex}.z = zdata;
-    
-else
-    
-    %-contour type-%
-    obj.data{contourIndex}.type = 'surface';
-    
-    %-contour x and y data
-    if isvector(xdata)
-        [xdata, ydata] = meshgrid(xdata, ydata);
-    end
-    obj.data{contourIndex}.x = xdata;
-    obj.data{contourIndex}.y = ydata;
+    %---------------------------------------------------------------------%
     
     %-contour z data-%
     obj.data{contourIndex}.z = zdata;
     
-    %-setting for contour lines z-direction-%
-    if length(contour_data.LevelList) > 1
-        zstart = contour_data.LevelList(1);
-        zend = contour_data.LevelList(end);
-        zsize = mean(diff(contour_data.LevelList));
-    else
-        zstart = contour_data.LevelList(1) - 1e-3;
-        zend = contour_data.LevelList(end) + 1e-3;
-        zsize = 2e-3;
-    end
-    l = 30;
-    obj.data{contourIndex}.contours.z.start = zstart;
-    obj.data{contourIndex}.contours.z.end = zend;
-    obj.data{contourIndex}.contours.z.size = zsize;
-    obj.data{contourIndex}.contours.z.show = true;
-    obj.data{contourIndex}.contours.z.usecolormap = true;
-    obj.data{contourIndex}.contours.z.width = contour_data.LineWidth;
-    obj.data{contourIndex}.hidesurface = true;
-    
-end
-
-%-------------------------------------------------------------------------%
-
-if isvector(zdata)
+    %---------------------------------------------------------------------%
     
     %-contour x type-%
 
     obj.data{contourIndex}.xtype = 'array';
 
-    %-------------------------------------------------------------------------%
+    %---------------------------------------------------------------------%
 
     %-contour y type-%
 
     obj.data{contourIndex}.ytype = 'array';
     
-end
-
-%-------------------------------------------------------------------------%
-
-%-contour visible-%
-
-obj.data{contourIndex}.visible = strcmp(contour_data.Visible,'on');
-
-%-------------------------------------------------------------------------%
-
-%-contour showscale-%
-obj.data{contourIndex}.showscale = false;
-
-%-------------------------------------------------------------------------%
-
-if isvector(zdata)
+    %---------------------------------------------------------------------%
+    
     %-zauto-%
     obj.data{contourIndex}.zauto = false;
 
-    %-------------------------------------------------------------------------%
+    %---------------------------------------------------------------------%
 
     %-zmin-%
     obj.data{contourIndex}.zmin = axis_data.CLim(1);
 
-    %-------------------------------------------------------------------------%
+    %---------------------------------------------------------------------%
 
     %-zmax-%
     obj.data{contourIndex}.zmax = axis_data.CLim(2);
-end
-
-%-------------------------------------------------------------------------%
-
-%-colorscale (ASSUMES PATCH CDATAMAP IS 'SCALED')-%
-colormap = figure_data.Colormap;
-
-for c = 1:size((colormap),1)
-    col =  255*(colormap(c,:));
-    obj.data{contourIndex}.colorscale{c} = {(c-1)/(size(colormap,1)-1), ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')']};
-end
-
-%-------------------------------------------------------------------------%
-
-%-contour reverse scale-%
-obj.data{contourIndex}.reversescale = false;
-
-%-------------------------------------------------------------------------%
-
-if isvector(zdata)
+    
+    %---------------------------------------------------------------------%
     
     %-autocontour-%
     obj.data{contourIndex}.autocontour = false;
     
-end
-
-%-------------------------------------------------------------------------%
-
-if isvector(zdata)
+    %---------------------------------------------------------------------%
     
     %-contour contours-%
 
@@ -229,11 +163,9 @@ if isvector(zdata)
     %-step-%
     obj.data{contourIndex}.contours.size = diff(contour_data.TextList(1:2));
     
-end
-
-%-------------------------------------------------------------------------%
-
-if isvector(zdata)
+    %---------------------------------------------------------------------%
+    
+    %-contour line setting-%
     if(~strcmp(contour_data.LineStyle,'none'))
 
         %-contour line colour-%
@@ -270,7 +202,134 @@ if isvector(zdata)
         obj.data{contourIndex}.contours.showlines = false;
 
     end
+    
+    %---------------------------------------------------------------------%
+    
+else
+    
+    %---------------------------------------------------------------------%
+    
+    %-contour type-%
+    obj.data{contourIndex}.type = 'surface';
+    
+    %---------------------------------------------------------------------%
+    
+    %-contour x and y data
+    if isvector(xdata)
+        [xdata, ydata] = meshgrid(xdata, ydata);
+    end
+    obj.data{contourIndex}.x = xdata;
+    obj.data{contourIndex}.y = ydata;
+    
+    %---------------------------------------------------------------------%
+    
+    %-contour z data-%
+    obj.data{contourIndex}.z = zdata;
+    
+    %---------------------------------------------------------------------%
+    
+    %-setting for contour lines z-direction-%
+    if length(contour_data.LevelList) > 1
+        zstart = contour_data.LevelList(1);
+        zend = contour_data.LevelList(end);
+        zsize = mean(diff(contour_data.LevelList));
+    else
+        zstart = contour_data.LevelList(1) - 1e-3;
+        zend = contour_data.LevelList(end) + 1e-3;
+        zsize = 2e-3;
+    end
+    
+    obj.data{contourIndex}.contours.z.start = zstart;
+    obj.data{contourIndex}.contours.z.end = zend;
+    obj.data{contourIndex}.contours.z.size = zsize;
+    obj.data{contourIndex}.contours.z.show = true;
+    obj.data{contourIndex}.contours.z.usecolormap = true;
+    obj.data{contourIndex}.contours.z.width = 2*contour_data.LineWidth;
+    obj.data{contourIndex}.hidesurface = true;
+    
+    %---------------------------------------------------------------------%
+    
+    %-colorscale-%
+    colormap = figure_data.Colormap;
+
+    for c = 1:size((colormap),1)
+        col =  255*(colormap(c,:));
+        obj.data{contourIndex}.colorscale{c} = {(c-1)/(size(colormap,1)-1), ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')']};
+    end
+    
+    %---------------------------------------------------------------------%
+    
+    %-aspect ratio-%
+    ar = obj.PlotOptions.AspectRatio;
+    
+    if ~isempty(ar)
+        if ischar(ar)
+            obj.layout.scene.aspectmode = ar;
+        elseif isvector(ar) && length(ar) == 3
+            xar = ar(1);
+            yar = ar(2);
+            zar = ar(3);
+        end
+    else
+        
+        %-define as default-%
+        xar = max(xdata(:));
+        yar = max(ydata(:));
+        zar = 0.7*max([xar, yar]);
+    end
+    
+    obj.layout.scene.aspectratio.x = xar;
+    obj.layout.scene.aspectratio.y = yar;
+    obj.layout.scene.aspectratio.z = zar;
+    
+    %---------------------------------------------------------------------%
+    
+    %-camera eye-%
+    ey = obj.PlotOptions.CameraEye;
+    
+    if ~isempty(ey)
+        if isvector(ey) && length(ey) == 3
+            obj.layout.scene.camera.eye.x = ey(1);
+            obj.layout.scene.camera.eye.y = ey(2);
+            obj.layout.scene.camera.eye.z = ey(3);
+        end
+    else
+        
+        %-define as default-%
+        xey = min(xdata(:)); if xey>0 xfac = -0.2; else xfac = 0.2; end
+        yey = min(ydata(:)); if yey>0 yfac = -0.2; else yfac = 0.2; end
+        if zar>0 zfac = -0.15; else zfac = 0.15; end
+        
+        obj.layout.scene.camera.eye.x = xey + xfac*xey;
+        obj.layout.scene.camera.eye.y = yey + yfac*yey;
+        obj.layout.scene.camera.eye.z = zar + yfac*zar;
+    end
+    
+    %---------------------------------------------------------------------%
+    
+    %-zerolines hidded-%
+    obj.layout.scene.xaxis.zeroline = false;
+    obj.layout.scene.yaxis.zeroline = false;
+    obj.layout.scene.zaxis.zeroline = false;
+    
+    %---------------------------------------------------------------------%
+    
 end
+
+%-------------------------------------------------------------------------%
+
+%-contour visible-%
+obj.data{contourIndex}.visible = strcmp(contour_data.Visible,'on');
+
+%-------------------------------------------------------------------------%
+
+%-contour showscale-%
+obj.data{contourIndex}.showscale = false;
+
+%-------------------------------------------------------------------------%
+
+%-contour reverse scale-%
+obj.data{contourIndex}.reversescale = false;
 
 %-------------------------------------------------------------------------%
 


### PR DESCRIPTION
This PR fix issues with using `contour3`. Specifically regarding AspectRatio and CameraEye on the plotly figure. Two new optional parameters are proposed for this:

- AspectRatio
- CameraEye

Those parameter can be passed when we invoke fig2plotly, but they can set by default as well

<img width="1444" alt="Screen Shot 2021-08-19 at 10 57 34 AM" src="https://user-images.githubusercontent.com/56391490/130098978-419728ed-7e41-43ce-9b0c-db0274258317.png">
<img width="1297" alt="Screen Shot 2021-08-19 at 11 40 46 AM" src="https://user-images.githubusercontent.com/56391490/130099069-41d7f9a5-8009-45d3-92fb-a88401d6c771.png">
