### PR TITLE
Fix histogram2 issues used in ssim baselines matlab code examples data distribution plots histogram2

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -671,9 +671,8 @@ classdef plotlyfig < handle
                 updateData(obj,n);
                 
                 try
-                    if (strcmp(obj.data{n}.type, 'bar') && update_opac(length(ax)-n))
-                        obj.data{1, n}.opacity = 0.9;
-                        obj.data{1, n}.marker.color = 'rgb(0,113.985,188.955)';
+                    if update_opac(length(ax)-n)
+                        % obj.data{1, n}.opacity = 0.9;
                     end
                 catch
                     % TODO to the future

--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -15,6 +15,10 @@ try
             updatePolarplot(obj, dataIndex);
         elseif strcmpi(obj.PlotOptions.TreatAs, 'contour3')
             updateContour3(obj, dataIndex);
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'compass')
+            updateLineseries(obj, dataIndex);
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'ezpolar')
+            updateLineseries(obj, dataIndex);
         end
         
     %-update plot based on plot call class-%

--- a/plotly/plotlyfig_aux/handlegraphics/updateHistogram2.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateHistogram2.m
@@ -58,6 +58,17 @@ obj.data{histIndex}.flatshading = true;
 
 %---------------------------------------------------------------------%
 
+%-lighting settings-%
+obj.data{histIndex}.lighting.diffuse = 0.92;
+obj.data{histIndex}.lighting.ambient = 0.54;
+obj.data{histIndex}.lighting.specular = 1.42;
+obj.data{histIndex}.lighting.roughness = 0.52;
+obj.data{histIndex}.lighting.fresnel = 0.2;
+obj.data{histIndex}.lighting.vertexnormalsepsilon = 1e-12;
+obj.data{histIndex}.lighting.facenormalsepsilon = 1e-6;
+
+%---------------------------------------------------------------------%
+
 %-aspect ratio-%
 ar = obj.PlotOptions.AspectRatio;
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateLineseries.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateLineseries.m
@@ -66,23 +66,14 @@ eval(['yaxis = obj.layout.yaxis' num2str(ysource) ';']);
 %-------------------------------------------------------------------------%
 
 %-if polar plot or not-%
-ispolar = false;
+treatas = obj.PlotOptions.TreatAs;
+ispolar = strcmpi(treatas, 'compass') || strcmpi(treatas, 'ezpolar');
+
+%-------------------------------------------------------------------------%
+
+%-getting data-%
 x = plot_data.XData;
 y = plot_data.YData;
-
-if length(x)==5 && length(y)==5 && x(2)==x(4) && y(2)==y(4)
-    ispolar = true;
-end
-
-%-if ezpolar or not-%
-len = length(obj.State.Axis.Handle.Children);
-if len > 1
-    for l = 1:len
-        if strcmpi(obj.State.Axis.Handle.Children(l).Type, 'Text')
-            ispolar = true;
-        end
-    end
-end
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/helpers/extractLineMarker.m
+++ b/plotly/plotlyfig_aux/helpers/extractLineMarker.m
@@ -28,8 +28,10 @@ if ~strcmp(line_data.Marker,'none')
     switch line_data.Marker
         case '.'
             marksymbol = 'circle';
+            marker.size = 0.4*line_data.MarkerSize;
         case 'o'
             marksymbol = 'circle';
+            marker.size = 0.4*line_data.MarkerSize;
         case 'x'
             marksymbol = 'x-thin-open';
         case '+'

--- a/plotly/plotlyfig_aux/helpers/extractPatchFace.m
+++ b/plotly/plotlyfig_aux/helpers/extractPatchFace.m
@@ -50,6 +50,9 @@ else
             end
             
             marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+
+        case 'auto'
+            marker.color = 'rgb(0,113.985,188.955)';
             
     end
 end
@@ -57,7 +60,6 @@ end
 %-------------------------------------------------------------------------%
 
 %-PATCH EDGE COLOR-%
-
 if isnumeric(patch_data.EdgeColor)
     
     col = 255*patch_data.EdgeColor;


### PR DESCRIPTION
This PR fix almost all issues for `histogram2` https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/data-distribution-plots/histogram2

Please test all those examples
Here some examples

<img width="1267" alt="Screen Shot 2021-08-23 at 9 08 12 PM" src="https://user-images.githubusercontent.com/56391490/130539469-e0db07b0-803c-4efd-abca-4c3505a65f96.png">
<img width="1311" alt="Screen Shot 2021-08-23 at 9 08 31 PM" src="https://user-images.githubusercontent.com/56391490/130539485-3b6ffd5e-b2b9-4d29-8824-37a2fc745219.png">
<img width="1292" alt="Screen Shot 2021-08-23 at 9 09 19 PM" src="https://user-images.githubusercontent.com/56391490/130539517-346b8feb-10f6-44ab-8588-01f722f51f20.png">
