### PR TITLE
debugging title issue, 2d plot tick, camera position 3d

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -451,6 +451,15 @@ classdef plotlyfig < handle
             handleFileName(obj);
             
             % handle title (for feed)
+            
+            % if only 1 plot
+            %obj.layout.title=obj.PlotOptions.FileName;
+            obj.layout.title=obj.State.Axis.Handle.Title.String;
+            obj.layout.titlefont.color='rgb(38.25,38.25,38.25)';%obj.State.Axis.Handle.Title.Color;
+            %obj.layout.title.size=25;%obj.State.Axis.Handle.Title.size;
+            %obj.layout.title.family='Arial, sans-serif';%obj.State.Axis.Handle.Title.FontName          
+
+                       
             if obj.PlotOptions.CleanFeedTitle
                 try
                     cleanFeedTitle(obj);
@@ -482,7 +491,7 @@ classdef plotlyfig < handle
                     web(response.url, '-browser');
                 end
             else
-                obj.url = plotlyoffline(obj);   
+                obj.url = plotlyoffline(obj);   %%
                 if obj.PlotOptions.OpenURL
                     web(obj.url, '-browser');
                 end
@@ -663,7 +672,7 @@ classdef plotlyfig < handle
                     end
                 catch
                     % TODO to the future
-                    % disp('catch at line 664 in plotlyfig.m file')
+                    % disp('catch at line 664 in plotlyfig_correction.m file')
                 end
                 
             end
@@ -678,7 +687,7 @@ classdef plotlyfig < handle
                     end
                 catch
                     % TODO to the future
-                    % disp('catch at line 679 in plotlyfig.m file')
+                    % disp('catch at line 679 in plotlyfig_correction.m file')
                 end
             end
             

--- a/plotly/plotlyfig_aux/core/updateAxis.m
+++ b/plotly/plotlyfig_aux/core/updateAxis.m
@@ -1,4 +1,4 @@
-%----UPDATE AXIS DATA/LAYOUT----%
+%----UPDATE AXIS DATA/layout----%
 
 function obj = updateAxis(obj,axIndex)
 

--- a/plotly/plotlyfig_aux/core/updateFigure.m
+++ b/plotly/plotlyfig_aux/core/updateFigure.m
@@ -64,7 +64,7 @@ end
 obj.layout.margin.l = 0;
 obj.layout.margin.r = 0;
 obj.layout.margin.b = 0;
-obj.layout.margin.t = 0;
+obj.layout.margin.t = 100; 
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/helpers/extractAxisData.m
+++ b/plotly/plotlyfig_aux/helpers/extractAxisData.m
@@ -53,8 +53,23 @@ axis.linecolor = axiscol;
 axis.tickcolor = axiscol;
 %-axis tickfont-%
 axis.tickfont.color = axiscol;
+% %-axis tickmode-%
+ axis.tickmode='array';
+ 
+% %-axis tickvals-%
+if axisName=='X'
+    axis.tickvals=obj.State.Axis.Handle.XTick;%axis.tickvals=[1,3,5];
+elseif axisName=='Y'
+    axis.tickvals=obj.State.Axis.Handle.YTick;
+elseif axisName=='Z'
+    axis.tickvals=obj.State.Axis.Handle.ZTick;
+end
+% %axis ticktext-%
+ %axis.ticktext=['one','three','five','sdf','efr'];
+
 %-axis grid color-%
 axis.gridcolor = axiscol;
+
 
 %-------------------------------------------------------------------------%
 


### PR DESCRIPTION
Part 1: The **title error** occurring throughout was due to two reasons. 
1) title wasn't taken as input.
2) even if we put the title, it was getting out of the window since, the margin was zero.

These two issues have been addressed by assigning 'title' to 'obj.layout.title'. The top margin has been manually kept at 100.
Title issue is solved for 2d and 3d plots.

Part 2: Another issue was with **'ticks'**. 
The problem was tickmode was **'auto'** and they weren't taking input from the Matlab plot.
This is addressed by making tickmode as **'array'** and using **'tickvals'**.

But, unfortunately, the same corrections didn't correct the ticks in the 3d plot. They remained 'auto' even after making direct changes in 'HTML file. So, the issue could be with the plotly.plot (plotly.newPlot). I found the same issue being discussed on StackExchange: https://stackoverflow.com/questions/37689268/is-it-possible-to-manually-set-the-scale-and-ticks-on-a-plot-ly-3d-scatter-graph

The HTML file with direct changes is attached below: Directly inserting 'tickvals' had no effect on 3d ticks.

Part 3: **Camera position** for 3d

For defining the position of the initial position of the 3d plot, all the 'layout' variables should come within 'scene' as shown in the HTML file attached .ie., 'obj. layout' should become 'obj.scene.layout'. But, doing that hampered the 2d plots, therefore I have not implemented them in code. Therefore, I have attached the HTML file that can rotate according to requirements. Currently, it will show the top view.

Since, I cannot attach an HTML file, I am attaching it as text. please change .txt to .html.

[3dcameracorrection.txt](https://github.com/plotly/plotly_matlab/files/7047517/3dcameracorrection.txt)

with regards,
Chaitanya S K
chaitanya.acharya.007@gmail.com


