### PR TITLE
Adding pareto functionality to fig2plotly

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -562,17 +562,21 @@ classdef plotlyfig < handle
             temp_ax = ax; deleted_idx = 0;
             for i = 1:length(ax)
                 for j = i:length(ax)
-                    if ((mean(eq(ax(i).Position, ax(j).Position)) == 1) && (i~=j) && strcmp(ax(i).Children.Type, 'histogram'))
-                        temp_plots = findobj(temp_ax(i),'-not','Type','Text','-not','Type','axes','-depth',1);
-                        if isprop(temp_plots, 'FaceAlpha')
-                            update_opac(i) = true;
-                        else
-                            update_opac(i) = false;
+                    try
+                        if ((mean(eq(ax(i).Position, ax(j).Position)) == 1) && (i~=j) && strcmp(ax(i).Children.Type, 'histogram'))
+                            temp_plots = findobj(temp_ax(i),'-not','Type','Text','-not','Type','axes','-depth',1);
+                            if isprop(temp_plots, 'FaceAlpha')
+                                update_opac(i) = true;
+                            else
+                                update_opac(i) = false;
+                            end
+                            temp_ax(i).YTick = temp_ax(j- deleted_idx).YTick;
+                            temp_ax(i).XTick = temp_ax(j- deleted_idx).XTick;
+                            temp_ax(j - deleted_idx) = []; 
+                            deleted_idx = deleted_idx + 1;
                         end
-                        temp_ax(i).YTick = temp_ax(j- deleted_idx).YTick;
-                        temp_ax(i).XTick = temp_ax(j- deleted_idx).XTick;
-                        temp_ax(j - deleted_idx) = []; 
-                        deleted_idx = deleted_idx + 1;
+                    catch
+                        % TODO: error with ax(i).Children.Type. isfield is no enogh
                     end
                 end
             end
@@ -624,6 +628,13 @@ classdef plotlyfig < handle
                     obj.State.Plot(obj.State.Figure.NumPlots).Handle = handle(plots(nprev));
                     obj.State.Plot(obj.State.Figure.NumPlots).AssociatedAxis = handle(ax(axrev));
                     obj.State.Plot(obj.State.Figure.NumPlots).Class = getGraphClass(plots(nprev));
+                end
+
+                % this works for pareto
+                if length(plots) == 0
+                    if obj.State.Figure.NumPlots ~=0
+                        obj.State.Plot(obj.State.Figure.NumPlots).AssociatedAxis = handle(ax(axrev));
+                    end
                 end
                 
                 % find text of figure

--- a/plotly/plotlyfig_aux/handlegraphics/updateHistogram.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateHistogram.m
@@ -191,7 +191,15 @@ end
 
 %-------------------------------------------------------------------------%
 
+%-marker data-%
 obj.data{histIndex}.marker = extractPatchFace(hist_data);
+
+%-------------------------------------------------------------------------%
+
+%-change color when multiple histograms same axes-%
+if min([xsource, ysource]) == 1
+    obj.data{histIndex}.marker = rmfield(obj.data{histIndex}.marker, 'color');
+end
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateStem.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateStem.m
@@ -142,13 +142,19 @@ function obj = updateStem3(obj,dataIndex)
   linecolor = cell(3*npoints,1);
   hidecolor = 'rgba(0,0,0,0)';
 
-  markercolor(1:3:3*npoints) = {hidecolor};
-  markercolor(2:3:3*npoints) = {stem_data.marker.color};
-  markercolor(3:3:3*npoints) = {hidecolor};
-
   linecolor(1:3:3*npoints) = {hidecolor};
-  linecolor(2:3:3*npoints) = {stem_data.marker.line.color};
+  markercolor(1:3:3*npoints) = {hidecolor};
+
+  try
+    linecolor(2:3:3*npoints) = {stem_data.marker.line.color};
+    markercolor(2:3:3*npoints) = {stem_data.marker.color};
+  catch
+    linecolor(2:3:3*npoints) = {stem_data.marker.color};
+    markercolor(2:3:3*npoints) = {hidecolor};
+  end
+  
   linecolor(3:3:3*npoints) = {hidecolor};
+  markercolor(3:3:3*npoints) = {hidecolor};
 
   %-add new marker/line colors-%
   stem_data.marker.color = markercolor;

--- a/plotly/plotlyfig_aux/helpers/extractAxisData.m
+++ b/plotly/plotlyfig_aux/helpers/extractAxisData.m
@@ -91,7 +91,6 @@ axis.gridwidth = linewidth;
 %-------------------------------------------------------------------------%
 
 %-axis type-%
-
 axis.type = eval(['axis_data.' axisName 'Scale']);
 
 %-------------------------------------------------------------------------%
@@ -120,6 +119,9 @@ if isempty(tick)
     %---------------------------------------------------------------------%
 
 else
+
+    %-get axis limits-%
+    dataLim = eval( sprintf('axis_data.%sLim', axisName) );
     
     %-axis tick direction-%
     switch axis_data.TickDir
@@ -140,10 +142,11 @@ else
     
     %---------------------------------------------------------------------%
     
+    %-LOG TYPE-%
     if strcmp(axis.type,'log')
         
         %-axis range-%
-        axis.range = eval(['log10(axis_data.' axisName 'Lim);']);
+        axis.range = eval( sprintf('log10(dataLim)') ); %['log10(axis_data.' axisName 'Lim);']);
         %-axis autotick-%
         axis.autotick = true;
         %-axis nticks-%
@@ -151,12 +154,18 @@ else
      
     %---------------------------------------------------------------------%
     
+    %-LINEAR TYPE-%
     elseif strcmp(axis.type,'linear')
+
+        %-----------------------------------------------------------------%
+
+        %-get tick label mode-%
         TickLabelMode = eval(['axis_data.' axisName 'TickLabelMode;']);
+
+        %-----------------------------------------------------------------%
+
+        %-AUTO MODE-%
         if strcmp(TickLabelMode,'auto')
-            
-            %-axis range-%
-            dataLim = eval(['axis_data.' axisName 'Lim']);
             
             %-------------------------------------------------------------%
             
@@ -192,39 +201,94 @@ else
             axis.autotick = true;
             %-axis numticks-%       
             axis.nticks = eval(['length(axis_data.' axisName 'Tick)+1']);
+
         %-----------------------------------------------------------------%
         
+        %-CUSTOM MODE-%
         else
-            %-axis show tick labels-%
-            Tick = eval(['axis_data.' axisName 'TickLabel;']);
-            if isempty(Tick)
+
+            %-------------------------------------------------------------%
+
+            %-get tick labels-%
+            tickLabels = eval(['axis_data.' axisName 'TickLabel;']);
+
+            %-------------------------------------------------------------%
+
+            %-hide tick labels as lichkLabels field is empty-%
+            if isempty(tickLabels)
+                
+                %-------------------------------------------------------------%
+
                 %-hide tick labels-%
                 axis.showticklabels = false;
+
+                %-------------------------------------------------------------%
+
                 %-axis autorange-%
                 axis.autorange = true;
+
+                %-------------------------------------------------------------%
+
+            %-axis show tick labels as tickLabels matlab field-%
             else
-                %-axis labels
-                labels = str2double(axis_data.YTickLabel);
-                try 
-                    %find numbers in labels
-                    labelnums = find(~isnan(labels));
-                    %-axis type linear-%
-                    axis.type = 'linear';
-                    %-range (overwrite)-%
-                    delta = (labels(labelnums(2)) - labels(labelnums(1)))/(labelnums(2)-labelnums(1));
-                    axis.range = [labels(labelnums(1))-delta*(labelnums(1)-1) labels(labelnums(1)) + (length(labels)-labelnums(1))*delta];
-                    %-axis autotick-%
-                    axis.autotick = true;
-                    %-axis numticks-%
-                    axis.nticks = eval(['length(axis_data.' axisName 'Tick) + 1;']);
-                catch
-                    %-axis type category-%
-                    axis.type = 'category';
-                    %-range (overwrite)-%
+
+                %-------------------------------------------------------------%
+
+                axis.showticklabels = true;
+                axis.type = 'linear';
+
+                %-------------------------------------------------------------%
+
+                if isnumeric(dataLim)
+                    axis.range = eval(['axis_data.' axisName 'Lim;']);
+                else
                     axis.autorange = true;
-                    %-axis autotick-%
-                    % axis.autotick = true;
                 end
+                
+                %-------------------------------------------------------------%
+
+                axis.tickvals = tick;
+                axis.ticktext = tickLabels;
+
+                %-------------------------------------------------------------%
+
+                %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++%
+                % NOTE: 
+                %    The next piece of code was replaced by the previous one. 
+                %    I think that the new piece of code is better, optimal and 
+                %    extends to all cases. However, I will leave this piece of 
+                %    code commented in case there is a problem in the future.
+                %
+                %    If there is a problem with the new piece of code, please 
+                %    comment and uncomment the next piece of code.
+                %
+                %    If everything goes well with the new gripping piece, at 
+                %    the end of the development we will be able to remove the 
+                %    commented lines
+                %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++%
+
+                %-axis labels
+                % labels = str2double(tickLabels);
+                % try 
+                %     %find numbers in labels
+                %     labelnums = find(~isnan(labels));
+                %     %-axis type linear-%
+                %     axis.type = 'linear';
+                %     %-range (overwrite)-%
+                %     delta = (labels(labelnums(2)) - labels(labelnums(1)))/(labelnums(2)-labelnums(1));
+                %     axis.range = [labels(labelnums(1))-delta*(labelnums(1)-1) labels(labelnums(1)) + (length(labels)-labelnums(1))*delta];
+                %     %-axis autotick-%
+                %     axis.autotick = true;
+                %     %-axis numticks-%
+                %     axis.nticks = eval(['length(axis_data.' axisName 'Tick) + 1;']);
+                % catch
+                %     %-axis type category-%
+                %     axis.type = 'category';
+                %     %-range (overwrite)-%
+                %     axis.autorange = true;
+                %     %-axis autotick-%
+                %     % axis.autotick = true;
+                % end
             end
         end
     end

--- a/plotly/plotlyfig_aux/helpers/extractLineMarker.m
+++ b/plotly/plotlyfig_aux/helpers/extractLineMarker.m
@@ -69,7 +69,7 @@ marker.line.width = line_data.LineWidth;
 %-------------------------------------------------------------------------%
 
 filledMarkerSet = {'o','square','s','diamond','d',...
-    'v','^', '<','>','hexagram','pentagram', '*', '+'};
+    'v','^', '<','>','hexagram','pentagram'};
 
 filledMarker = ismember(line_data.Marker,filledMarkerSet);
 

--- a/plotly/plotlyfig_aux/helpers/extractPatchFace.m
+++ b/plotly/plotlyfig_aux/helpers/extractPatchFace.m
@@ -44,12 +44,16 @@ else
                     capCD = max(min(patch_data.FaceVertexCData(1,1),axis_data.CLim(2)),axis_data.CLim(1));
                     scalefactor = (capCD -axis_data.CLim(1))/diff(axis_data.CLim);
                     col =  255*(colormap(1+ floor(scalefactor*(length(colormap)-1)),:));
-                case {'direct', 'auto'}
+                case 'direct'
+                    patch_data.FaceVertexCData
                     col =  255*(colormap(patch_data.FaceVertexCData(1,1),:));
                     
             end
             
             marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+
+        case 'auto'
+            marker.color = 'rgb(0,113.985,188.955)';
     end
 end
 


### PR DESCRIPTION
This PR add `pareto` functionality to `fig2plotly` library. Previously `pareto` matlab function was not implemented in `fig2plotly`.

This PR was tested for all cases in https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/discrete-data-plots/pareto and work perfectly for all cases.

Please test all cases there. Here I attach one example case

```
codelines = [200 120 555 608 1024 101 57 687];
coders = {'Fred','Ginger','Norman','Max','Julia','Wally','Heidi','Pat'};

figure
pareto(codelines, coders)
title('Lines of Code by Programmer');

f = fig2plotly(gcf, 'offline', 0);
```

Attach bellow screenshots of results 

<img width="1396" alt="Screen Shot 2021-09-08 at 8 43 34 PM" src="https://user-images.githubusercontent.com/56391490/132605420-bab2dec0-e75c-44c4-bf82-ef51798caab5.png">
<img width="1387" alt="Screen Shot 2021-09-08 at 8 43 58 PM" src="https://user-images.githubusercontent.com/56391490/132605461-f8b3be2b-caf9-48ae-ae21-c2a6f4a27815.png">
<img width="1388" alt="Screen Shot 2021-09-08 at 8 44 18 PM" src="https://user-images.githubusercontent.com/56391490/132605502-1da880d8-401c-4bdb-84a8-0d54de855e46.png">

links to Chart-Studio:

https://chart-studio.plotly.com/~galvisgilberto/4132/#/
https://chart-studio.plotly.com/~galvisgilberto/4134/lines-of-code-by-programmer/#/
https://chart-studio.plotly.com/~galvisgilberto/4136/#/

**NOTA**
It is worth noting that, for this PR, an important change in the `extractAxisData.m` file was introduced, which optimally and automatically sets the `ticklabels` in the axes. Please check that file for more details on lines 235 to 291