### PR TITLE
Fix issues and awesome improve the bar3 functionality

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -562,17 +562,21 @@ classdef plotlyfig < handle
             temp_ax = ax; deleted_idx = 0;
             for i = 1:length(ax)
                 for j = i:length(ax)
-                    if ((mean(eq(ax(i).Position, ax(j).Position)) == 1) && (i~=j) && strcmp(ax(i).Children.Type, 'histogram'))
-                        temp_plots = findobj(temp_ax(i),'-not','Type','Text','-not','Type','axes','-depth',1);
-                        if isprop(temp_plots, 'FaceAlpha')
-                            update_opac(i) = true;
-                        else
-                            update_opac(i) = false;
+                    try
+                        if ((mean(eq(ax(i).Position, ax(j).Position)) == 1) && (i~=j) && strcmp(ax(i).Children.Type, 'histogram'))
+                            temp_plots = findobj(temp_ax(i),'-not','Type','Text','-not','Type','axes','-depth',1);
+                            if isprop(temp_plots, 'FaceAlpha')
+                                update_opac(i) = true;
+                            else
+                                update_opac(i) = false;
+                            end
+                            temp_ax(i).YTick = temp_ax(j- deleted_idx).YTick;
+                            temp_ax(i).XTick = temp_ax(j- deleted_idx).XTick;
+                            temp_ax(j - deleted_idx) = []; 
+                            deleted_idx = deleted_idx + 1;
                         end
-                        temp_ax(i).YTick = temp_ax(j- deleted_idx).YTick;
-                        temp_ax(i).XTick = temp_ax(j- deleted_idx).XTick;
-                        temp_ax(j - deleted_idx) = []; 
-                        deleted_idx = deleted_idx + 1;
+                    catch
+                        % TODO: error with ax(i).Children.Type. isfield is no enogh
                     end
                 end
             end
@@ -624,6 +628,13 @@ classdef plotlyfig < handle
                     obj.State.Plot(obj.State.Figure.NumPlots).Handle = handle(plots(nprev));
                     obj.State.Plot(obj.State.Figure.NumPlots).AssociatedAxis = handle(ax(axrev));
                     obj.State.Plot(obj.State.Figure.NumPlots).Class = getGraphClass(plots(nprev));
+                end
+
+                % this works for pareto
+                if length(plots) == 0
+                    if obj.State.Figure.NumPlots ~=0
+                        obj.State.Plot(obj.State.Figure.NumPlots).AssociatedAxis = handle(ax(axrev));
+                    end
                 end
                 
                 % find text of figure

--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -22,7 +22,9 @@ try
         elseif strcmpi(obj.PlotOptions.TreatAs, 'polarhistogram')
             updateHistogramPolar(obj, dataIndex); 
         elseif strcmpi(obj.PlotOptions.TreatAs, 'coneplot')
-            updateConeplot(obj, dataIndex); 
+            updateConeplot(obj, dataIndex);
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'bar3')
+            updateBar3(obj, dataIndex); 
 
         % this one will be revomed
         elseif strcmpi(obj.PlotOptions.TreatAs, 'streamtube')

--- a/plotly/plotlyfig_aux/handlegraphics/updateBar3.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateBar3.m
@@ -1,0 +1,363 @@
+function obj = updateBar3(obj, surfaceIndex)
+
+%-AXIS INDEX-%
+axIndex = obj.getAxisIndex(obj.State.Plot(surfaceIndex).AssociatedAxis);
+
+%-CHECK FOR MULTIPLE AXES-%
+[xsource, ysource] = findSourceAxis(obj,axIndex);
+
+%-SURFACE DATA STRUCTURE- %
+bar_data = get(obj.State.Plot(surfaceIndex).Handle);
+figure_data = get(obj.State.Figure.Handle);
+
+%-AXIS STRUCTURE-%
+axis_data = get(ancestor(bar_data.Parent,'axes'));
+
+%-GET SCENE-%
+eval(['scene = obj.layout.scene' num2str(xsource) ';']);
+
+%-------------------------------------------------------------------------%
+
+%-associate scene-%
+obj.data{surfaceIndex}.scene = sprintf('scene%d', xsource);
+    
+%-------------------------------------------------------------------------%
+
+%-surface type-%
+obj.data{surfaceIndex}.type = 'mesh3d';
+
+%-------------------------------------------------------------------------%
+    
+%-FORMAT DATA-%
+xdata = bar_data.XData;
+ydata = bar_data.YData;
+zdata = bar_data.ZData;
+cdata = bar_data.CData;
+
+%-parse xedges-%
+xedges = xdata(2, 1:2:end);
+
+%-parse yedges-%
+yedges = ydata(2:6:end, 2);
+yedges = [yedges', mean(diff(yedges(1:2)))];
+
+%-parse values-%
+values = [];
+for n = 1:6:size(zdata, 1)
+    values = [values, diff(zdata(n:n+1, 2))];
+end
+
+%-parse offsets-%
+offsets = zdata(1:6:end, 2)';
+    
+%-------------------------------------------------------------------------%
+
+%-get the values to use plotly's mesh3D-%
+bargap = diff(yedges(1:2)) - diff(ydata(2:3));
+[X, Y, Z, I, J, K] = get_plotly_mesh3d(xedges, yedges, values, bargap);
+
+%---------------------------------------------------------------------%
+
+%-reformat Z according to offsets-%
+m = 1;
+lz2 = 0.5*length(Z);
+
+for n = 1:4:lz2
+    Z(n:n+3) = Z(n:n+3)+offsets(m);
+    Z(n+lz2:n+lz2+3) = Z(n+lz2:n+lz2+3)+offsets(m);
+    m = m + 1;
+end
+
+%-------------------------------------------------------------------------%
+
+%-set mesh3d data-%
+obj.data{surfaceIndex}.x = X;
+obj.data{surfaceIndex}.y = Y;
+obj.data{surfaceIndex}.z = Z;
+obj.data{surfaceIndex}.i = int16(I-1);
+obj.data{surfaceIndex}.j = int16(J-1);
+obj.data{surfaceIndex}.k = int16(K-1);
+
+%-------------------------------------------------------------------------%
+
+%-coloring-%
+cmap = figure_data.Colormap;
+
+if isnumeric(bar_data.FaceColor)
+    
+    %-paper_bgcolor-%
+    col = 255*bar_data.FaceColor;
+    col = sprintf('rgb(%f,%f,%f)', col);
+    
+else
+    switch bar_data.FaceColor
+        
+        case 'none'
+            marker.color = 'rgba(0,0,0,0)';
+            
+        case {'flat','interp'}
+            
+            switch bar_data.CDataMapping
+                
+                case 'scaled'
+                    capCD = max(min(cdata(1,1),axis_data.CLim(2)),axis_data.CLim(1));
+                    scalefactor = (capCD - axis_data.CLim(1))/diff(axis_data.CLim);
+                    col =  255*(cmap(1+ floor(scalefactor*(length(cmap)-1)),:));
+                case 'direct'
+                    col =  255*(cmap(cdata(1,1),:));
+                    
+            end
+            
+            col = sprintf('rgb(%f,%f,%f)', col);
+
+        case 'auto'
+            col = 'rgb(0,113.985,188.955)';
+    end
+end
+
+obj.data{surfaceIndex}.color = col;
+
+%-------------------------------------------------------------------------%
+
+%-some settings-%
+obj.data{surfaceIndex}.contour.show = true;
+obj.data{surfaceIndex}.contour.width = 6;
+obj.data{surfaceIndex}.contour.color='rgb(0,0,0)';
+obj.data{surfaceIndex}.flatshading = false;
+
+%-------------------------------------------------------------------------%
+
+%-lighting settings-%
+obj.data{surfaceIndex}.lighting.diffuse = 0.8;
+obj.data{surfaceIndex}.lighting.ambient = 0.65;
+obj.data{surfaceIndex}.lighting.specular = 1.42;
+obj.data{surfaceIndex}.lighting.roughness = 0.52;
+obj.data{surfaceIndex}.lighting.fresnel = 0.2;
+obj.data{surfaceIndex}.lighting.vertexnormalsepsilon = 1e-12;
+obj.data{surfaceIndex}.lighting.facenormalsepsilon = 1e-6;
+
+obj.data{surfaceIndex}.lightposition.x = 0;
+obj.data{surfaceIndex}.lightposition.y = 0;
+obj.data{surfaceIndex}.lightposition.z = 0;
+
+%-------------------------------------------------------------------------%
+
+%-surface name-%
+obj.data{surfaceIndex}.name = bar_data.DisplayName;
+
+%-------------------------------------------------------------------------%
+
+%-surface visible-%
+obj.data{surfaceIndex}.visible = strcmp(bar_data.Visible,'on');
+
+%-------------------------------------------------------------------------%
+
+leg = get(bar_data.Annotation);
+legInfo = get(leg.LegendInformation);
+
+switch legInfo.IconDisplayStyle
+    case 'on'
+        showleg = true;
+    case 'off'
+        showleg = false;
+end
+
+obj.data{surfaceIndex}.showlegend = showleg;
+
+%-------------------------------------------------------------------------%
+
+%-SETTING SCENE-%
+
+%-------------------------------------------------------------------------%
+
+%-aspect ratio-%
+ar = obj.PlotOptions.AspectRatio;
+
+if ~isempty(ar)
+    if ischar(ar)
+        scene.aspectmode = ar;
+    elseif isvector(ar) && length(ar) == 3
+        xar = ar(1);
+        yar = ar(2);
+        zar = ar(3);
+    end
+else
+
+    %-define as default-%
+    xar = max(xedges(:));
+    yar = max(yedges(:));
+    zar = 0.7*max([xar, yar]);
+end
+
+scene.aspectratio.x = xar;
+scene.aspectratio.y = yar;
+scene.aspectratio.z = zar;
+
+%-------------------------------------------------------------------------%
+
+%-camera eye-%
+ey = obj.PlotOptions.CameraEye;
+
+if ~isempty(ey)
+    if isvector(ey) && length(ey) == 3
+        scene.camera.eye.x = ey(1);
+        scene.camera.eye.y = ey(2);
+        scene.camera.eye.z = ey(3);
+    end
+else
+
+    %-define as default-%
+    xey = xar; if xey>0 xfac = 5; else xfac = 0.5*length(values); end
+    yey = yar; if yey>0 yfac = 0.1; else yfac = -0.1; end
+    if zar>0 zfac = -0.05; else zfac = 0.1; end
+    
+    scene.camera.eye.x = xey + 7; 
+    scene.camera.eye.y = yey - 2;
+    scene.camera.eye.z = zar + 0.5;
+end
+
+%-------------------------------------------------------------------------%
+
+%-axis configuration-%
+scene.xaxis.range = axis_data.XLim(end:-1:1);
+scene.yaxis.range = axis_data.YLim;
+scene.zaxis.range = axis_data.ZLim;
+
+scene.xaxis.tickvals = axis_data.XTick;
+scene.xaxis.ticktext = axis_data.XTickLabel;
+
+scene.yaxis.tickvals = axis_data.YTick;
+scene.yaxis.ticktext = axis_data.YTickLabel;
+
+scene.zaxis.tickvals = axis_data.ZTick;
+scene.zaxis.ticktext = axis_data.ZTickLabel;
+
+scene.yaxis.zeroline = false;
+scene.yaxis.zeroline = false;
+scene.zaxis.zeroline = false;
+
+scene.xaxis.showline = true;
+scene.yaxis.showline = true;
+scene.zaxis.showline = true;
+
+scene.xaxis.tickcolor = 'rgba(0,0,0,1)';
+scene.yaxis.tickcolor = 'rgba(0,0,0,1)';
+scene.zaxis.tickcolor = 'rgba(0,0,0,1)';
+
+scene.xaxis.ticklabelposition = 'outside';
+scene.yaxis.ticklabelposition = 'outside';
+scene.zaxis.ticklabelposition = 'outside';
+
+scene.xaxis.title = axis_data.XLabel.String;
+scene.yaxis.title = axis_data.YLabel.String;
+scene.zaxis.title = axis_data.ZLabel.String;
+
+%-------------------------------------------------------------------------%
+
+%-SET SCENE TO LAYOUT-%
+obj.layout = setfield(obj.layout, sprintf('scene%d', xsource), scene);
+
+%-------------------------------------------------------------------------%
+
+end
+
+function bar_ = bar_data(position3d, size_)
+    % position3d - 3-list or array of shape (3,) that represents the point of coords (x, y, 0), where a bar is placed
+    % size = a 3-tuple whose elements are used to scale a unit cube to get a paralelipipedic bar
+    % returns - an array of shape(8,3) representing the 8 vertices of  a bar at position3d
+
+    if nargin < 2
+        size_ = [1, 1, 1];
+    end
+
+    bar_ = [...
+            0, 0, 0; ...
+            1, 0, 0; ...
+            1, 1, 0; ...
+            0, 1, 0; ...
+            0, 0, 1; ...
+            1, 0, 1; ...
+            1, 1, 1; ...
+            0, 1, 1 ...
+            ]; % the vertices of the unit cube
+
+    for n =1:size(bar_, 1)
+        bar_(n,:) = bar_(n,:) .* size_; % scale the cube to get the vertices of a parallelipipedic bar_
+    end
+
+
+    bar_ = bar_ + position3d; %translate each  bar_ on the directio OP, with P=position3d
+end
+
+function [vertices, I, J, K] = triangulate_bar_faces(positions, sizes)
+    % positions - array of shape (N, 3) that contains all positions in the plane z=0, where a histogram bar is placed 
+    % sizes -  array of shape (N,3); each row represents the sizes to scale a unit cube to get a bar
+    % returns the array of unique vertices, and the lists i, j, k to be used in instantiating the go.Mesh3d class
+
+    if nargin < 2
+        sizes = ones(size(positions,1), 3); %[(1,1,1)]*len(positions)
+    else
+        sizes;
+        % if isinstance(sizes, (list, np.ndarray)) and len(sizes) != len(positions):
+        %     raise ValueError('Your positions and sizes lists/arrays do not have the same length')
+    end
+
+    c = 1;
+    for n = 1:size(positions, 1)
+        if sizes(n, 3) ~= 0
+            all_bars(:,:,c) = bar_data(positions(n,:), sizes(n,:))';
+            c = c+1;
+        end
+    end
+
+    % all_bars = [bar_data(pos, size)  for pos, size in zip(positions, sizes) if size[2]!=0]
+    [r, q, p] = size(all_bars);
+
+    % extract unique vertices from the list of all bar vertices
+    all_bars = reshape(all_bars, [r, p*q])';
+    [vertices, ~, ixr] = unique(all_bars, 'rows');
+
+    %for each bar, derive the sublists of indices i, j, k assocated to its chosen  triangulation
+    I = [];
+    J = [];
+    K = [];
+
+    for k = 0:p-1
+        aux = ixr([1+8*k, 1+8*k+2,1+8*k, 1+8*k+5,1+8*k, 1+8*k+7, 1+8*k+5, 1+8*k+2, 1+8*k+3, 1+8*k+6, 1+8*k+7, 1+8*k+5]);
+        I = [ I;  aux(:)];
+        aux = ixr([1+8*k+1, 1+8*k+3, 1+8*k+4, 1+8*k+1, 1+8*k+3, 1+8*k+4, 1+8*k+1, 1+8*k+6, 1+8*k+7, 1+8*k+2, 1+8*k+4, 1+8*k+6]);
+        J = [ J;  aux(:)];
+        aux = ixr([1+8*k+2, 1+8*k, 1+8*k+5, 1+8*k, 1+8*k+7, 1+8*k, 1+8*k+2, 1+8*k+5, 1+8*k+6, 1+8*k+3, 1+8*k+5, 1+8*k+7]);
+        K = [ K;  aux(:)];
+    end
+
+end
+
+function [X, Y, Z, I, J, K] = get_plotly_mesh3d(xedges, yedges, values, bargap)
+    % x, y- array-like of shape (n,), defining the x, and y-ccordinates of data set for which we plot a 3d hist
+
+    xsize = xedges(2)-xedges(1)-bargap;
+    ysize = yedges(2)-yedges(1)-bargap;
+    [xe, ye]= meshgrid(xedges(1:end-1), yedges(1:end-1));
+    ze = zeros(size(xe));
+
+    positions = zeros([size(xe), 3]);
+    positions(:,:,1) = xe;
+    positions(:,:,2) = ye;
+    positions(:,:,3) = ze;
+
+    [m, n, p] = size(positions);
+    positions = reshape(positions, [m*n, p]);
+
+    h = values'; h = h(:);
+    sizes = [];
+    for n = 1:length(h)
+        sizes = [sizes; ysize, ysize, h(n)];
+    end
+
+    [vertices, I, J, K]  = triangulate_bar_faces(positions, sizes);
+    X = vertices(:,1);
+    Y = vertices(:,2);
+    Z = vertices(:,3);
+
+end

--- a/plotly/plotlyfig_aux/handlegraphics/updateHistogram.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateHistogram.m
@@ -191,7 +191,15 @@ end
 
 %-------------------------------------------------------------------------%
 
+%-marker data-%
 obj.data{histIndex}.marker = extractPatchFace(hist_data);
+
+%-------------------------------------------------------------------------%
+
+%-change color when multiple histograms same axes-%
+if min([xsource, ysource]) == 1
+    obj.data{histIndex}.marker = rmfield(obj.data{histIndex}.marker, 'color');
+end
 
 %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateStem.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateStem.m
@@ -142,13 +142,19 @@ function obj = updateStem3(obj,dataIndex)
   linecolor = cell(3*npoints,1);
   hidecolor = 'rgba(0,0,0,0)';
 
-  markercolor(1:3:3*npoints) = {hidecolor};
-  markercolor(2:3:3*npoints) = {stem_data.marker.color};
-  markercolor(3:3:3*npoints) = {hidecolor};
-
   linecolor(1:3:3*npoints) = {hidecolor};
-  linecolor(2:3:3*npoints) = {stem_data.marker.line.color};
+  markercolor(1:3:3*npoints) = {hidecolor};
+
+  try
+    linecolor(2:3:3*npoints) = {stem_data.marker.line.color};
+    markercolor(2:3:3*npoints) = {stem_data.marker.color};
+  catch
+    linecolor(2:3:3*npoints) = {stem_data.marker.color};
+    markercolor(2:3:3*npoints) = {hidecolor};
+  end
+  
   linecolor(3:3:3*npoints) = {hidecolor};
+  markercolor(3:3:3*npoints) = {hidecolor};
 
   %-add new marker/line colors-%
   stem_data.marker.color = markercolor;

--- a/plotly/plotlyfig_aux/helpers/extractAxisData.m
+++ b/plotly/plotlyfig_aux/helpers/extractAxisData.m
@@ -91,7 +91,6 @@ axis.gridwidth = linewidth;
 %-------------------------------------------------------------------------%
 
 %-axis type-%
-
 axis.type = eval(['axis_data.' axisName 'Scale']);
 
 %-------------------------------------------------------------------------%
@@ -120,6 +119,9 @@ if isempty(tick)
     %---------------------------------------------------------------------%
 
 else
+
+    %-get axis limits-%
+    dataLim = eval( sprintf('axis_data.%sLim', axisName) );
     
     %-axis tick direction-%
     switch axis_data.TickDir
@@ -140,10 +142,11 @@ else
     
     %---------------------------------------------------------------------%
     
+    %-LOG TYPE-%
     if strcmp(axis.type,'log')
         
         %-axis range-%
-        axis.range = eval(['log10(axis_data.' axisName 'Lim);']);
+        axis.range = eval( sprintf('log10(dataLim)') ); %['log10(axis_data.' axisName 'Lim);']);
         %-axis autotick-%
         axis.autotick = true;
         %-axis nticks-%
@@ -151,12 +154,18 @@ else
      
     %---------------------------------------------------------------------%
     
+    %-LINEAR TYPE-%
     elseif strcmp(axis.type,'linear')
+
+        %-----------------------------------------------------------------%
+
+        %-get tick label mode-%
         TickLabelMode = eval(['axis_data.' axisName 'TickLabelMode;']);
+
+        %-----------------------------------------------------------------%
+
+        %-AUTO MODE-%
         if strcmp(TickLabelMode,'auto')
-            
-            %-axis range-%
-            dataLim = eval(['axis_data.' axisName 'Lim']);
             
             %-------------------------------------------------------------%
             
@@ -192,39 +201,94 @@ else
             axis.autotick = true;
             %-axis numticks-%       
             axis.nticks = eval(['length(axis_data.' axisName 'Tick)+1']);
+
         %-----------------------------------------------------------------%
         
+        %-CUSTOM MODE-%
         else
-            %-axis show tick labels-%
-            Tick = eval(['axis_data.' axisName 'TickLabel;']);
-            if isempty(Tick)
+
+            %-------------------------------------------------------------%
+
+            %-get tick labels-%
+            tickLabels = eval(['axis_data.' axisName 'TickLabel;']);
+
+            %-------------------------------------------------------------%
+
+            %-hide tick labels as lichkLabels field is empty-%
+            if isempty(tickLabels)
+                
+                %-------------------------------------------------------------%
+
                 %-hide tick labels-%
                 axis.showticklabels = false;
+
+                %-------------------------------------------------------------%
+
                 %-axis autorange-%
                 axis.autorange = true;
+
+                %-------------------------------------------------------------%
+
+            %-axis show tick labels as tickLabels matlab field-%
             else
-                %-axis labels
-                labels = str2double(axis_data.YTickLabel);
-                try 
-                    %find numbers in labels
-                    labelnums = find(~isnan(labels));
-                    %-axis type linear-%
-                    axis.type = 'linear';
-                    %-range (overwrite)-%
-                    delta = (labels(labelnums(2)) - labels(labelnums(1)))/(labelnums(2)-labelnums(1));
-                    axis.range = [labels(labelnums(1))-delta*(labelnums(1)-1) labels(labelnums(1)) + (length(labels)-labelnums(1))*delta];
-                    %-axis autotick-%
-                    axis.autotick = true;
-                    %-axis numticks-%
-                    axis.nticks = eval(['length(axis_data.' axisName 'Tick) + 1;']);
-                catch
-                    %-axis type category-%
-                    axis.type = 'category';
-                    %-range (overwrite)-%
+
+                %-------------------------------------------------------------%
+
+                axis.showticklabels = true;
+                axis.type = 'linear';
+
+                %-------------------------------------------------------------%
+
+                if isnumeric(dataLim)
+                    axis.range = eval(['axis_data.' axisName 'Lim;']);
+                else
                     axis.autorange = true;
-                    %-axis autotick-%
-                    % axis.autotick = true;
                 end
+                
+                %-------------------------------------------------------------%
+
+                axis.tickvals = tick;
+                axis.ticktext = tickLabels;
+
+                %-------------------------------------------------------------%
+
+                %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++%
+                % NOTE: 
+                %    The next piece of code was replaced by the previous one. 
+                %    I think that the new piece of code is better, optimal and 
+                %    extends to all cases. However, I will leave this piece of 
+                %    code commented in case there is a problem in the future.
+                %
+                %    If there is a problem with the new piece of code, please 
+                %    comment and uncomment the next piece of code.
+                %
+                %    If everything goes well with the new gripping piece, at 
+                %    the end of the development we will be able to remove the 
+                %    commented lines
+                %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++%
+
+                %-axis labels
+                % labels = str2double(tickLabels);
+                % try 
+                %     %find numbers in labels
+                %     labelnums = find(~isnan(labels));
+                %     %-axis type linear-%
+                %     axis.type = 'linear';
+                %     %-range (overwrite)-%
+                %     delta = (labels(labelnums(2)) - labels(labelnums(1)))/(labelnums(2)-labelnums(1));
+                %     axis.range = [labels(labelnums(1))-delta*(labelnums(1)-1) labels(labelnums(1)) + (length(labels)-labelnums(1))*delta];
+                %     %-axis autotick-%
+                %     axis.autotick = true;
+                %     %-axis numticks-%
+                %     axis.nticks = eval(['length(axis_data.' axisName 'Tick) + 1;']);
+                % catch
+                %     %-axis type category-%
+                %     axis.type = 'category';
+                %     %-range (overwrite)-%
+                %     axis.autorange = true;
+                %     %-axis autotick-%
+                %     % axis.autotick = true;
+                % end
             end
         end
     end

--- a/plotly/plotlyfig_aux/helpers/extractLineMarker.m
+++ b/plotly/plotlyfig_aux/helpers/extractLineMarker.m
@@ -69,7 +69,7 @@ marker.line.width = line_data.LineWidth;
 %-------------------------------------------------------------------------%
 
 filledMarkerSet = {'o','square','s','diamond','d',...
-    'v','^', '<','>','hexagram','pentagram', '*', '+'};
+    'v','^', '<','>','hexagram','pentagram'};
 
 filledMarker = ismember(line_data.Marker,filledMarkerSet);
 

--- a/plotly/plotlyfig_aux/helpers/extractPatchFace.m
+++ b/plotly/plotlyfig_aux/helpers/extractPatchFace.m
@@ -44,12 +44,16 @@ else
                     capCD = max(min(patch_data.FaceVertexCData(1,1),axis_data.CLim(2)),axis_data.CLim(1));
                     scalefactor = (capCD -axis_data.CLim(1))/diff(axis_data.CLim);
                     col =  255*(colormap(1+ floor(scalefactor*(length(colormap)-1)),:));
-                case {'direct', 'auto'}
+                case 'direct'
+                    patch_data.FaceVertexCData
                     col =  255*(colormap(patch_data.FaceVertexCData(1,1),:));
                     
             end
             
             marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+
+        case 'auto'
+            marker.color = 'rgb(0,113.985,188.955)';
     end
 end
 


### PR DESCRIPTION
This PR fix issues and improve the `bar3` functionality. `bar3` previous version was very poor. This new version is really awesome. This PR was tested for all examples in https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/discrete-data-plots/bar3

It is very important to highlight that to use this new functionality `TreatAs` optional parameter must set to `bar3`. Example of usage bellow

```
load count.dat
Z = count(1:10,:);
figure
bar3(Z,'stacked')
title('Stacked Style');

f = fig2plotly(gcf, 'offline', 0, 'TreatAs', 'bar3');
```

Screenshots of results are shown bellow

<img width="1308" alt="Screen Shot 2021-09-10 at 11 56 38 AM" src="https://user-images.githubusercontent.com/56391490/132883163-23cf8a49-3cd5-433d-95a0-dc846d093dc7.png">
<img width="1293" alt="Screen Shot 2021-09-10 at 11 56 56 AM" src="https://user-images.githubusercontent.com/56391490/132883169-90c485af-2016-4d5d-b63a-30119370b5aa.png">
<img width="1289" alt="Screen Shot 2021-09-10 at 11 57 14 AM" src="https://user-images.githubusercontent.com/56391490/132883172-b82c9267-3c43-4f94-a5e0-d9e27bab1959.png">
<img width="1291" alt="Screen Shot 2021-09-10 at 11 57 31 AM" src="https://user-images.githubusercontent.com/56391490/132883174-080f2154-95b7-41cb-91ad-c37947c7bba1.png">

links to Chart-Studio:

https://chart-studio.plotly.com/~galvisgilberto/4176/detached-style/#/
https://chart-studio.plotly.com/~galvisgilberto/4178/bar-width-of-05/#/
https://chart-studio.plotly.com/~galvisgilberto/4180/grouped-style/#/
https://chart-studio.plotly.com/~galvisgilberto/4182/stacked-style/#/