### PR TITLE
fix issues and awesome improvements in mesh functionality

### DIFF
--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -30,7 +30,9 @@ try
         elseif strcmpi(obj.PlotOptions.TreatAs, 'surf')
             updateSurf(obj, dataIndex); 
         elseif strcmpi(obj.PlotOptions.TreatAs, 'fmesh')
-            updateFmesh(obj, dataIndex); 
+            updateFmesh(obj, dataIndex);
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'mesh')
+            updateMesh(obj, dataIndex); 
 
         % this one will be revomed
         elseif strcmpi(obj.PlotOptions.TreatAs, 'streamtube')

--- a/plotly/plotlyfig_aux/handlegraphics/updateMesh.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateMesh.m
@@ -1,4 +1,4 @@
-function obj = updateSurf(obj, surfaceIndex)
+function obj = updateMesh(obj, surfaceIndex)
 
 %-AXIS INDEX-%
 axIndex = obj.getAxisIndex(obj.State.Plot(surfaceIndex).AssociatedAxis);

--- a/plotly/plotlyfig_aux/handlegraphics/updateScatterhistogram.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateScatterhistogram.m
@@ -65,8 +65,8 @@ for t=1:length(xdata)
 
   p = t;
   if t > 1
-    obj.PlotOptions.nplots = obj.PlotOptions.nplots + 1;
-    p = obj.PlotOptions.nplots;
+    obj.PlotOptions.nPlots = obj.PlotOptions.nPlots + 1;
+    p = obj.PlotOptions.nPlots;
   end
 
   %-----------------------------------------------------------------------%
@@ -253,8 +253,8 @@ end
 
 for t=1:length(xdata)
 
-  obj.PlotOptions.nplots = obj.PlotOptions.nplots + 1;
-  p = obj.PlotOptions.nplots;
+  obj.PlotOptions.nPlots = obj.PlotOptions.nPlots + 1;
+  p = obj.PlotOptions.nPlots;
 
   if t == 1
     ps = p;
@@ -367,8 +367,8 @@ obj.layout.bargap = 0.05;
 
 for t=1:length(xdata)
 
-  obj.PlotOptions.nplots = obj.PlotOptions.nplots + 1;
-  p = obj.PlotOptions.nplots;
+  obj.PlotOptions.nPlots = obj.PlotOptions.nPlots + 1;
+  p = obj.PlotOptions.nPlots;
 
   if t == 1
     ps = p;


### PR DESCRIPTION
This PR fix issues and do awesome improvements with `mesh` functionality. `mesh` previous version was very poor. This new version is really awesome. This PR was tested for all examples in https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/surface-and-mesh-plots/mesh

It is very important to highlight that to use this new functionality, `TreatAs` optional parameter must set to `mesh`. Example of usage bellow

```
[X,Y] = meshgrid(-8:.5:8);
R = sqrt(X.^2 + Y.^2) + eps;
Z = sin(R)./R;
C = X.*Y;
mesh(X,Y,Z,C)
colorbar;

f = fig2plotly(gcf, 'offline', false, 'TreatAs', 'mesh');
```

Screenshots of results are shown bellow

<img width="1309" alt="Screen Shot 2021-09-15 at 6 59 57 PM" src="https://user-images.githubusercontent.com/56391490/133524386-a74a7b24-1a28-4e2a-85ad-74cb60656054.png">
<img width="1345" alt="Screen Shot 2021-09-15 at 7 00 42 PM" src="https://user-images.githubusercontent.com/56391490/133524403-99a1ba17-b0c8-496e-94e8-6c126ec79d40.png">
<img width="1332" alt="Screen Shot 2021-09-15 at 7 01 40 PM" src="https://user-images.githubusercontent.com/56391490/133524407-72a5848f-cbbb-45bc-a53c-0b3fcb2d2227.png">
<img width="1334" alt="Screen Shot 2021-09-15 at 7 02 36 PM" src="https://user-images.githubusercontent.com/56391490/133524410-11abe399-6122-4a3b-82a1-8d6a1c1976ec.png">
<img width="1327" alt="Screen Shot 2021-09-15 at 7 03 22 PM" src="https://user-images.githubusercontent.com/56391490/133524413-9317e03c-e4e4-497f-8e50-5affcede30b0.png">

Links to Chart-Studio

https://chart-studio.plotly.com/~galvisgilberto/4392/#/
https://chart-studio.plotly.com/~galvisgilberto/4394/#/
https://chart-studio.plotly.com/~galvisgilberto/4396/#/
https://chart-studio.plotly.com/~galvisgilberto/4398/#/
https://chart-studio.plotly.com/~galvisgilberto/4400/#/

