### PR TITLE
fix issues and awesome improvements in surfl functionality

### DIFF
--- a/plotly/plotlyfig_aux/core/updateData.m
+++ b/plotly/plotlyfig_aux/core/updateData.m
@@ -37,6 +37,8 @@ try
             updateSurfc(obj, dataIndex); 
         elseif strcmpi(obj.PlotOptions.TreatAs, 'meshc')
             updateSurfc(obj, dataIndex); 
+        elseif strcmpi(obj.PlotOptions.TreatAs, 'surfl')
+            updateSurfl(obj, dataIndex);
 
         % this one will be revomed
         elseif strcmpi(obj.PlotOptions.TreatAs, 'streamtube')

--- a/plotly/plotlyfig_aux/handlegraphics/updateSurf.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateSurf.m
@@ -71,6 +71,21 @@ obj.data{surfaceIndex}.x = xDataSurface;
 obj.data{surfaceIndex}.y = yDataSurface;
 obj.data{surfaceIndex}.z = zDataSurface;
 
+%- setting grid mesh by default -%
+% x-direction
+xData = xData(1, :);
+obj.data{surfaceIndex}.contours.x.start = xData(1);
+obj.data{surfaceIndex}.contours.x.end = xData(end);
+obj.data{surfaceIndex}.contours.x.size = mean(diff(xData));
+obj.data{surfaceIndex}.contours.x.show = true;
+
+% y-direction
+yData = yData(:, 1);
+obj.data{surfaceIndex}.contours.y.start = yData(1);
+obj.data{surfaceIndex}.contours.y.end = yData(end);
+obj.data{surfaceIndex}.contours.y.size = mean(diff(yData));;
+obj.data{surfaceIndex}.contours.y.show = true;
+
 %-------------------------------------------------------------------------%
 
 %-set data on scatter3d-%
@@ -103,6 +118,9 @@ elseif strcmpi(meshData.EdgeColor, 'interp')
     cDataContour = zDataContour(:);
     obj.data{contourIndex}.line.colorscale = colorScale;
 
+    obj.data{surfaceIndex}.contours.x.show = false;
+    obj.data{surfaceIndex}.contours.y.show = false;
+
 elseif strcmpi(meshData.EdgeColor, 'flat')
     cData = meshData.CData;
 
@@ -132,13 +150,20 @@ elseif strcmpi(meshData.EdgeColor, 'flat')
     cDataContourDir2 = [cDataContourDir2; NaN(1, size(cDataContourDir2, 2))];
     cDataContour = [cDataContourDir1(:); cDataContourDir2(:)];
 
+    obj.data{surfaceIndex}.contours.x.show = false;
+    obj.data{surfaceIndex}.contours.y.show = false;
+
 elseif strcmpi(meshData.EdgeColor, 'none')
     cDataContour = 'rgba(0,0,0,0)';
+    obj.data{surfaceIndex}.contours.x.show = false;
+    obj.data{surfaceIndex}.contours.y.show = false;
 
 end
 
 %-set edge color-%
 obj.data{contourIndex}.line.color = cDataContour;
+obj.data{surfaceIndex}.contours.x.color = cDataContour;
+obj.data{surfaceIndex}.contours.y.color = cDataContour;
 
 %-------------------------------------------------------------------------%
 
@@ -202,6 +227,8 @@ elseif strcmpi(faceColor, 'flat')
         end
     else
         cDataSurface = cData;
+        obj.data{surfaceIndex}.cmin = axisData.CLim(1);
+        obj.data{surfaceIndex}.cmax = axisData.CLim(2);
     end
     
 end
@@ -239,15 +266,12 @@ obj.data{surfaceIndex}.opacity = meshData.FaceAlpha;
 
 obj.data{contourIndex}.line.width = 3*meshData.LineWidth;
 
-switch meshData.LineStyle
-    case '-'
-        obj.data{contourIndex}.line.dash = 'solid';
-    case '--'
-        obj.data{contourIndex}.line.dash = 'dash';
-    case '-.'
-        obj.data{contourIndex}.line.dash = 'dashdot';
-    case ':'
-        obj.data{contourIndex}.line.dash = 'dot';
+if strcmpi(meshData.LineStyle, '-')
+    obj.data{contourIndex}.line.dash = 'solid';
+else
+    obj.data{contourIndex}.line.dash = 'dot';
+    obj.data{surfaceIndex}.contours.x.show = false;
+    obj.data{surfaceIndex}.contours.y.show = false;
 end
 
 %-------------------------------------------------------------------------%

--- a/plotly/plotlyfig_aux/handlegraphics/updateSurfl.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateSurfl.m
@@ -1,4 +1,4 @@
-function obj = updateMesh(obj, surfaceIndex)
+function obj = updateSurfl(obj, surfaceIndex)
 
 %-AXIS INDEX-%
 axIndex = obj.getAxisIndex(obj.State.Plot(surfaceIndex).AssociatedAxis);


### PR DESCRIPTION
This PR fix issues and do awesome improvements with `surfl` functionality. `surfl` previous version was very poor and failed for many cases. This new version is really awesome and work for any case. This PR was tested for all examples in https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/surface-and-mesh-plots/surfl

It is very important to highlight that to use this new functionality, `'TreatAs'` optional parameter must set to `'surfl'`. Example of usage bellow

```
[X,Y] = meshgrid(1:0.5:10,1:20);
Z = sin(X) + cos(Y);
surfl(X,Y,Z);

fig2plotly(gcf, 'offline', false,  'TreatAs', 'surfl');
```

Screenshots of results are shown bellow

<img width="1312" alt="Screen Shot 2021-09-21 at 2 28 48 PM" src="https://user-images.githubusercontent.com/56391490/134227805-4a002fba-c9ea-463e-88c0-5017ffd7c5e3.png">
<img width="1323" alt="Screen Shot 2021-09-21 at 2 29 15 PM" src="https://user-images.githubusercontent.com/56391490/134227825-fe46f07e-979d-43d9-9b65-13b494a46c0b.png">
<img width="1313" alt="Screen Shot 2021-09-21 at 2 29 42 PM" src="https://user-images.githubusercontent.com/56391490/134227833-8e0e1222-9999-4d2f-9189-f9fa067fcc51.png">
<img width="1314" alt="Screen Shot 2021-09-21 at 2 31 05 PM" src="https://user-images.githubusercontent.com/56391490/134227841-c0ca8716-748e-462a-9009-187fdbd73a0c.png">
<img width="1316" alt="Screen Shot 2021-09-21 at 2 31 38 PM" src="https://user-images.githubusercontent.com/56391490/134227846-0bb10617-2c5d-4812-8ea1-a713e0b8bc69.png">

Links to Plotly Chart-Studio

https://chart-studio.plotly.com/~galvisgilberto/4446/#/
https://chart-studio.plotly.com/~galvisgilberto/4448/#/
https://chart-studio.plotly.com/~galvisgilberto/4450/#/
https://chart-studio.plotly.com/~galvisgilberto/4454/#/
https://chart-studio.plotly.com/~galvisgilberto/4456/#/
