### PR TITLE
add geoRenderType optional paramter to geoscatter geoplot and geobubble functionalities

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -60,6 +60,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.is_headmap_axis = false;
             obj.PlotOptions.Quality = -1;
             obj.PlotOptions.Zmin = [];
+            obj.PlotOptions.geoRenderType = 'geo';
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -250,6 +251,9 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'Zmin'))
                             obj.PlotOptions.Zmin = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'geoRenderType'))
+                            obj.PlotOptions.geoRenderType = varargin{a+1};
                         end
                     end
             end
@@ -1063,7 +1067,7 @@ classdef plotlyfig < handle
                         ||  strcmpi(fieldname,'yaxis') ||  strcmpi(fieldname,'cone')...
                         ||  strcmpi(fieldname,'legend') ||  strcmpi(fieldname,'histogram')...
                         ||  strcmpi(fieldname,'scatter') ||  strcmpi(fieldname,'line')...
-                        ||  strcmpi(fieldname,'scattergeo') ...
+                        ||  strcmpi(fieldname,'scattergeo') ||  strcmpi(fieldname,'scattermapbox')...
                         )
                         fprintf(['\nWhoops! ' exception.message(1:end-1) ' in ' fieldname '\n\n']);
                     end

--- a/plotly/plotlyfig_aux/handlegraphics/UpdateGeoAxes.m
+++ b/plotly/plotlyfig_aux/handlegraphics/UpdateGeoAxes.m
@@ -17,78 +17,96 @@ function UpdateGeoAxes(obj, geoIndex)
     w = geoData.Position(3);
     h = geoData.Position(4);
 
-    geo.domain.x = min([xo xo + w],1);
-    geo.domain.y = min([yo yo + h],1);
+    geoaxes.domain.x = min([xo xo + w],1);
+    geoaxes.domain.y = min([yo yo + h],1);
 
     %-------------------------------------------------------------------------%
 
     %-setting projection-%
-    geo.projection.type = 'mercator';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.projection.type = 'mercator';
+    end
 
     %-------------------------------------------------------------------------%
 
     %-setting basemap-%
-    geo.framecolor = 'rgb(120,120,120)';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.framecolor = 'rgb(120,120,120)';
 
-    if strcmpi(geoData.Basemap, 'streets-light')    
-        geo.oceancolor = 'rgba(20,220,220,1)';
-        geo.landcolor = 'rgba(20,220,220,0.2)';
-    elseif strcmpi(geoData.Basemap, 'colorterrain')
-        geo.oceancolor = 'rgba(118,165,225,0.6)';
-        geo.landcolor = 'rgba(190,180,170,1)';
-        geo.showcountries = true;
-        geo.showlakes = true;
+        if strcmpi(geoData.Basemap, 'streets-light')    
+            geoaxes.oceancolor = 'rgba(20,220,220,1)';
+            geoaxes.landcolor = 'rgba(20,220,220,0.2)';
+        elseif strcmpi(geoData.Basemap, 'colorterrain')
+            geoaxes.oceancolor = 'rgba(118,165,225,0.6)';
+            geoaxes.landcolor = 'rgba(190,180,170,1)';
+            geoaxes.showcountries = true;
+            geoaxes.showlakes = true;
+        end
+
+        geoaxes.showocean = true;
+        geoaxes.showcoastlines = false;
+        geoaxes.showland = true;
     end
-
-    geo.showocean = true;
-    geo.showcoastlines = false;
-    geo.showland = true;
 
     %-------------------------------------------------------------------------%
 
     %-setting latitude axis-%
-    latTick = geoData.LatitudeAxis.TickValues;
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        latTick = geoData.LatitudeAxis.TickValues;
 
-    geo.lataxis.range = geoData.LatitudeLimits;
-    geo.lataxis.tick0 = latTick(1);
-    geo.lataxis.dtick = mean(diff(latTick));
+        geoaxes.lataxis.range = geoData.LatitudeLimits;
+        geoaxes.lataxis.tick0 = latTick(1);
+        geoaxes.lataxis.dtick = mean(diff(latTick));
 
-    if strcmpi(geoData.Grid, 'on')
-        geo.lataxis.showgrid = true;
-        geo.lataxis.gridwidth = geoData.LineWidth;
-        geo.lataxis.gridcolor = sprintf('rgba(%f,%f,%f,%f)', 255*geoData.GridColor, geoData.GridAlpha);
+        if strcmpi(geoData.Grid, 'on')
+            geoaxes.lataxis.showgrid = true;
+            geoaxes.lataxis.gridwidth = geoData.LineWidth;
+            geoaxes.lataxis.gridcolor = sprintf('rgba(%f,%f,%f,%f)', 255*geoData.GridColor, geoData.GridAlpha);
+        end
     end
 
     %-------------------------------------------------------------------------%
     
     %-setting longitude axis-%
-    lonTick = geoData.LongitudeAxis.TickValues;
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        lonTick = geoData.LongitudeAxis.TickValues;
 
-    geo.lonaxis.range = geoData.LongitudeLimits;
-    geo.lonaxis.tick0 = lonTick(1);
-    geo.lonaxis.dtick = mean(diff(lonTick));
+        geoaxes.lonaxis.range = geoData.LongitudeLimits;
+        geoaxes.lonaxis.tick0 = lonTick(1);
+        geoaxes.lonaxis.dtick = mean(diff(lonTick));
 
-    if strcmpi(geoData.Grid, 'on')
-        geo.lonaxis.showgrid = true;
-        geo.lonaxis.gridwidth = geoData.LineWidth;
-        geo.lonaxis.gridcolor = sprintf('rgba(%f,%f,%f,%f)', 255*geoData.GridColor, geoData.GridAlpha);
+        if strcmpi(geoData.Grid, 'on')
+            geoaxes.lonaxis.showgrid = true;
+            geoaxes.lonaxis.gridwidth = geoData.LineWidth;
+            geoaxes.lonaxis.gridcolor = sprintf('rgba(%f,%f,%f,%f)', 255*geoData.GridColor, geoData.GridAlpha);
+        end
     end
 
     %-------------------------------------------------------------------------%
     
     %-set map center-%
-    geo.center.lat = geoData.MapCenter(1);
-    geo.center.lon = geoData.MapCenter(2);
+    geoaxes.center.lat = geoData.MapCenter(1);
+    geoaxes.center.lon = geoData.MapCenter(2);
 
     %-------------------------------------------------------------------------%
     
     %-set better resolution-%
-    geo.resolution = '50';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.resolution = '50';
+    end
 
-    %-------------------------------------------------------------------------%
+    %-----------------------------------------------------------------------------%
 
-    %-set geo axes to layout-%
-    obj.layout = setfield(obj.layout, sprintf('geo%d', xsource+1), geo);
+    %-set mapbox style-%
+    if strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        geoaxes.zoom = geoData.ZoomLevel - 1.4;
+
+        if strcmpi(geoData.Basemap, 'streets-light')
+            geoaxes.style = 'carto-positron';
+        elseif strcmpi(geoData.Basemap, 'colorterrain')
+            geoaxes.style = 'stamen-terrain';
+        end
+    end
 
     %-------------------------------------------------------------------------%
 
@@ -120,16 +138,38 @@ function UpdateGeoAxes(obj, geoIndex)
     end
 
     if isText
-        obj.data{geoIndex}.type = 'scattergeo';
+
+        if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+            obj.data{geoIndex}.type = 'scattergeo';
+        elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            obj.data{geoIndex}.type = 'scattermapbox';
+        end
+
         obj.data{geoIndex}.mode = 'text';
         obj.data{geoIndex}.text = texts;
         obj.data{geoIndex}.lat = lats;
         obj.data{geoIndex}.lon = lons;
-        obj.data{geoIndex}.geo = obj.data{geoIndex-1}.geo;
 
         obj.data{geoIndex}.textfont.size = sizes;
         obj.data{geoIndex}.textfont.color = colors;
         obj.data{geoIndex}.textfont.family = families;
         obj.data{geoIndex}.textposition = pos;
+
+        if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+            obj.data{geoIndex}.geo = obj.data{geoIndex-1}.geo;
+        elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            obj.data{geoIndex}.subplot = obj.data{geoIndex-1}.subplot;
+        end
     end
+
+    %-------------------------------------------------------------------------%
+
+    %-set geo axes to layout-%
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.layout = setfield(obj.layout, sprintf('geo%d', xsource+1), geoaxes);
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.layout = setfield(obj.layout, sprintf('mapbox%d', xsource+1), geoaxes);
+    end
+
+    %-------------------------------------------------------------------------%
 end

--- a/plotly/plotlyfig_aux/handlegraphics/updateGeoPlot.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateGeoPlot.m
@@ -12,12 +12,22 @@ function updateGeoPlot(obj,geoIndex)
     [xsource, ysource] = findSourceAxis(obj,axIndex);
 
     %-ASSOCIATE GEO-AXES LAYOUT-%
-    obj.data{geoIndex}.geo = sprintf('geo%d', xsource+1);
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.data{geoIndex}.geo = sprintf('geo%d', xsource+1);
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.data{geoIndex}.subplot = sprintf('mapbox%d', xsource+1);
+    end
 
     %-------------------------------------------------------------------------%
 
     %-set scattergeo type-%
-    obj.data{geoIndex}.type = 'scattergeo';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.data{geoIndex}.type = 'scattergeo';
+
+    %-set scattermapbox type-%
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.data{geoIndex}.type = 'scattermapbox';
+    end
 
     %-------------------------------------------------------------------------%
 
@@ -37,12 +47,24 @@ function updateGeoPlot(obj,geoIndex)
 
     %-------------------------------------------------------------------------%
 
-    %-set marker field-%
-    obj.data{geoIndex}.marker = marker;
-
+    %-corrections-%
     if strcmpi(geoData.Marker, 'none')
         obj.data{geoIndex}.mode = 'lines';
+    else
+        if strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            marker.allowoverlap = true;
+            marker = rmfield(marker, 'symbol');
+
+            if strcmp(marker.color, 'rgba(0,0,0,0)') && isfield(marker, 'line')
+                marker.color = marker.line.color;
+            end
+        end
     end
+
+    %-------------------------------------------------------------------------%
+
+    %-set marker field-%
+    obj.data{geoIndex}.marker = marker;
 
     %-------------------------------------------------------------------------%
 

--- a/plotly/plotlyfig_aux/handlegraphics/updateGeoScatter.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateGeoScatter.m
@@ -12,17 +12,27 @@ function updateGeoScatter(obj,geoIndex)
     [xsource, ysource] = findSourceAxis(obj,axIndex);
 
     %-ASSOCIATE GEO-AXES LAYOUT-%
-    obj.data{geoIndex}.geo = sprintf('geo%d', xsource+1);
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.data{geoIndex}.geo = sprintf('geo%d', xsource+1);
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.data{geoIndex}.subplot = sprintf('mapbox%d', xsource+1);
+    end
 
     %-------------------------------------------------------------------------%
 
     %-set scattergeo type-%
-    obj.data{geoIndex}.type = 'scattergeo';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.data{geoIndex}.type = 'scattergeo';
+
+    %-set scattermapbox type-%
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.data{geoIndex}.type = 'scattermapbox';
+    end
 
     %-------------------------------------------------------------------------%
 
     %-set scattergeo mode-%
-    obj.data{geoIndex}.mode = 'markers';
+    obj.data{geoIndex}.mode = 'markers+text';
 
     %-------------------------------------------------------------------------%
 
@@ -35,10 +45,19 @@ function updateGeoScatter(obj,geoIndex)
     %-get marker setting-%
     marker = extractGeoMarker(geoData, axisData);
 
+    if strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        marker.allowoverlap = true;
+        marker = rmfield(marker, 'symbol');
+
+        if strcmp(marker.color, 'rgba(0,0,0,0)') && isfield(marker, 'line')
+            marker.color = marker.line.color;
+        end
+    end
+
     %-------------------------------------------------------------------------%
 
     %-set marker field-%
-    obj.data{geoIndex}.marker = marker;   
+    obj.data{geoIndex}.marker = marker;
 
     %-------------------------------------------------------------------------%
 end

--- a/plotly/plotlyfig_aux/handlegraphics/updateGeobubble.m
+++ b/plotly/plotlyfig_aux/handlegraphics/updateGeobubble.m
@@ -72,7 +72,13 @@ function updateGeobubble(obj,geoIndex)
         %-------------------------------------------------------------------------%
 
         %-set scattergeo type-%
-        obj.data{p}.type = 'scattergeo';
+        if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+            obj.data{p}.type = 'scattergeo';
+
+        %-set scattermapbox type-%
+        elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            obj.data{p}.type = 'scattermapbox';
+        end
 
         %-------------------------------------------------------------------------%
 
@@ -101,7 +107,11 @@ function updateGeobubble(obj,geoIndex)
         %-------------------------------------------------------------------------%
 
         %-ASSOCIATE GEO-AXES LAYOUT-%
-        obj.data{p}.geo = sprintf('geo%d', xsource+1);
+        if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+            obj.data{p}.geo = sprintf('geo%d', xsource+1);
+        elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            obj.data{p}.subplot = sprintf('mapbox%d', xsource+1);
+        end
 
         %-------------------------------------------------------------------------%
 
@@ -122,76 +132,103 @@ function updateGeobubble(obj,geoIndex)
     %
     %=============================================================================%
 
-    %-set domain geo plot-%
+    %-set domain plot-%
     xo = geoData.Position(1);
     yo = geoData.Position(2);
     w = geoData.Position(3);
     h = geoData.Position(4);
 
-    geo.domain.x = min([xo xo + w],1);
-    geo.domain.y = min([yo yo + h],1);
+    geoaxes.domain.x = min([xo xo + w],1);
+    geoaxes.domain.y = min([yo yo + h],1);
 
     %-----------------------------------------------------------------------------%
 
     %-setting projection-%
-    geo.projection.type = 'mercator';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.projection.type = 'mercator';
+    end
 
     %-----------------------------------------------------------------------------%
 
     %-setting basemap-%
-    geo.framecolor = 'rgb(120,120,120)';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.framecolor = 'rgb(120,120,120)';
 
-    if strcmpi(geoData.Basemap, 'streets-light')    
-        geo.oceancolor = 'rgba(20,220,220,1)';
-        geo.landcolor = 'rgba(20,220,220,0.2)';
-    elseif strcmpi(geoData.Basemap, 'colorterrain')
-        geo.oceancolor = 'rgba(118,165,225,0.6)';
-        geo.landcolor = 'rgba(190,180,170,1)';
-        geo.showcountries = true;
-        geo.showlakes = true;
+        if strcmpi(geoData.Basemap, 'streets-light')
+            geoaxes.oceancolor = 'rgba(20,220,220,1)';
+            geoaxes.landcolor = 'rgba(20,220,220,0.2)';
+        elseif strcmpi(geoData.Basemap, 'colorterrain')
+            geoaxes.oceancolor = 'rgba(118,165,225,0.6)';
+            geoaxes.landcolor = 'rgba(190,180,170,1)';
+            geoaxes.showcountries = true;
+            geoaxes.showlakes = true;
+        end
+
+        geoaxes.showocean = true;
+        geoaxes.showcoastlines = false;
+        geoaxes.showland = true;
     end
-
-    geo.showocean = true;
-    geo.showcoastlines = false;
-    geo.showland = true;
 
     %-----------------------------------------------------------------------------%
 
     %-setting latitude axis-%
-    geo.lataxis.range = geoData.LatitudeLimits;
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.lataxis.range = geoData.LatitudeLimits;
 
-    if strcmpi(geoData.GridVisible, 'on')
-        geo.lataxis.showgrid = true;
-        geo.lataxis.gridwidth = 0.5;
-        geo.lataxis.gridcolor = 'rgba(38.250000,38.250000,38.250000,0.150000)';
+        if strcmpi(geoData.GridVisible, 'on')
+            geoaxes.lataxis.showgrid = true;
+            geoaxes.lataxis.gridwidth = 0.5;
+            geoaxes.lataxis.gridcolor = 'rgba(38.250000,38.250000,38.250000,0.150000)';
+        end
     end
 
     %-----------------------------------------------------------------------------%
     
     %-setting longitude axis-%
-    geo.lonaxis.range = geoData.LongitudeLimits;
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geoaxes.lonaxis.range = geoData.LongitudeLimits;
 
-    if strcmpi(geoData.GridVisible, 'on')
-        geo.lonaxis.showgrid = true;
-        geo.lonaxis.gridwidth = 0.5;
-        geo.lonaxis.gridcolor = 'rgba(38.250000,38.250000,38.250000,0.150000)';
+        if strcmpi(geoData.GridVisible, 'on')
+            geoaxes.lonaxis.showgrid = true;
+            geoaxes.lonaxis.gridwidth = 0.5;
+            geoaxes.lonaxis.gridcolor = 'rgba(38.250000,38.250000,38.250000,0.150000)';
+        end
     end
 
     %-----------------------------------------------------------------------------%
     
     %-set map center-%
-    geo.center.lat = geoData.MapCenter(1);
-    geo.center.lon = geoData.MapCenter(2);
+    geoaxes.center.lat = geoData.MapCenter(1);
+    geoaxes.center.lon = geoData.MapCenter(2);
 
     %-----------------------------------------------------------------------------%
     
     %-set better resolution-%
-    geo.resolution = '50';
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        geo.resolution = '50';
+    end
 
     %-----------------------------------------------------------------------------%
 
-    %-set geo axes to layout-%
-    obj.layout = setfield(obj.layout, sprintf('geo%d', xsource+1), geo);
+    %-set mapbox style-%
+    if strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        geoaxes.zoom = geoData.ZoomLevel - 1.4;
+
+        if strcmpi(geoData.Basemap, 'streets-light')
+            geoaxes.style = 'carto-positron';
+        elseif strcmpi(geoData.Basemap, 'colorterrain')
+            geoaxes.style = 'stamen-terrain';
+        end
+    end
+
+    %-----------------------------------------------------------------------------%
+
+    %-set geo geoaxes to layout-%
+    if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+        obj.layout = setfield(obj.layout, sprintf('geo%d', xsource+1), geoaxes);
+    elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+        obj.layout = setfield(obj.layout, sprintf('mapbox%d', xsource+1), geoaxes);
+    end
 
     %-----------------------------------------------------------------------------%
 
@@ -209,7 +246,7 @@ function updateGeobubble(obj,geoIndex)
       obj.layout.annotations{1}.yref = 'paper';
       obj.layout.annotations{1}.yanchor = 'top';
       obj.layout.annotations{1}.xanchor = 'middle';
-      obj.layout.annotations{1}.x = mean(geo.domain.x);
+      obj.layout.annotations{1}.x = mean(geoaxes.domain.x);
       obj.layout.annotations{1}.y = 0.96;
       obj.layout.annotations{1}.font.color = 'black';
       obj.layout.annotations{1}.font.family = matlab2plotlyfont(geoData.FontName);
@@ -234,8 +271,14 @@ function updateGeobubble(obj,geoIndex)
             obj.layout.legend.title.font.color = 'black';
         end
 
-        obj.layout.legend.x = geo.domain.x(end) * 0.980;
-        obj.layout.legend.y = geo.domain.y(end) * 1.001;
+        if strcmpi(obj.PlotOptions.geoRenderType, 'geo')
+            obj.layout.legend.x = geoaxes.domain.x(end)*0.975;
+            obj.layout.legend.y = geoaxes.domain.y(end)*1.001;
+        elseif strcmpi(obj.PlotOptions.geoRenderType, 'mapbox')
+            obj.layout.legend.x = geoaxes.domain.x(end)*1.005;
+            obj.layout.legend.y = geoaxes.domain.y(end)*1.0005;
+        end
+
         obj.layout.legend.xanchor = 'left';
         obj.layout.legend.yanchor = 'top';
         obj.layout.legend.itemsizing = 'constant';


### PR DESCRIPTION
This PR add a new optional parameter to `fig2plotly` which works for `geoscatter`, `geoplot` and `geobubble` functionalities. This optional parameter is called `'geoRenderType'` and it allows us to set the type of **rendering** that we want for the geographic charts. Among the rendering types we have: 1) `'geo'` (by default) which is based on **D3.js** and 2) `'mabox'` which is **tile-based**. `'mapbox'` is much more powerful in terms of visualization, but it has certain limitations regarding the configuration of markers and texts. The user can now choose the type of rendering they want.

This PR has been tested for all examples at https://github.com/plotly/ssim_baselines/tree/main/matlab/code-examples/geographic-plots.

I share below two examples (one for each type of rendering) using the `geoplot` functionality. However, both examples can be extended to the other two geographic chart functionalities (`geoscatter` and `geobubble`). Feel free to recreate these examples.

**`geo` rendering:**

```
latSeattle = 47.62;
lonSeattle = -122.33;
latAnchorage = 61.20;
lonAnchorage = -149.9;
geoplot([latSeattle latAnchorage],[lonSeattle lonAnchorage])
geolimits([45 62],[-149 -123]);
geobasemap colorterrain;

fig2plotly(gcf, 'offline', true, 'geoRenderType', 'geo');
```

**`mapbox` rendering:**

```
latSeattle = 47.62;
lonSeattle = -122.33;
latAnchorage = 61.20;
lonAnchorage = -149.9;
geoplot([latSeattle latAnchorage],[lonSeattle lonAnchorage])
geolimits([45 62],[-149 -123]);
geobasemap colorterrain;

fig2plotly(gcf, 'offline', true, 'geoRenderType', 'mapbox');
```

Attach bellow results all geographic charts as well as links to chart-studio for each redering type

**`geoscatter`:**

https://chart-studio.plotly.com/~galvisgilberto/4548/#/
https://chart-studio.plotly.com/~galvisgilberto/4550/#/
https://chart-studio.plotly.com/~galvisgilberto/4552/#/
https://chart-studio.plotly.com/~galvisgilberto/4554/#/

<img width="1391" alt="Screen Shot 2021-09-28 at 1 27 08 PM" src="https://user-images.githubusercontent.com/56391490/135143062-41d5d6eb-a401-496e-8cda-a13a0f9dc203.png">
<img width="1389" alt="Screen Shot 2021-09-28 at 1 31 07 PM" src="https://user-images.githubusercontent.com/56391490/135143089-5001adcb-ad79-4538-893e-f920821ecd26.png">
<img width="1386" alt="Screen Shot 2021-09-28 at 1 33 03 PM" src="https://user-images.githubusercontent.com/56391490/135143097-5ea46716-9e9f-4e0a-8ec8-d0619949f32c.png">
<img width="1395" alt="Screen Shot 2021-09-28 at 1 33 36 PM" src="https://user-images.githubusercontent.com/56391490/135143107-b1bcb11b-4353-4bbd-9ad7-faa8969d6a46.png">

**`geoplot`:**

https://chart-studio.plotly.com/~galvisgilberto/4556/#/
https://chart-studio.plotly.com/~galvisgilberto/4558/#/
https://chart-studio.plotly.com/~galvisgilberto/4560/#/
https://chart-studio.plotly.com/~galvisgilberto/4564/#/
https://chart-studio.plotly.com/~galvisgilberto/4566/#/
https://chart-studio.plotly.com/~galvisgilberto/4568/#/

<img width="1413" alt="Screen Shot 2021-09-28 at 1 40 06 PM" src="https://user-images.githubusercontent.com/56391490/135143207-1b167657-8a98-402d-b4af-10ce13ac65d1.png">
<img width="1409" alt="Screen Shot 2021-09-28 at 1 40 41 PM" src="https://user-images.githubusercontent.com/56391490/135143237-2a99e1f1-ce73-43ed-92f3-f8eca0692354.png">
<img width="1394" alt="Screen Shot 2021-09-28 at 1 41 50 PM" src="https://user-images.githubusercontent.com/56391490/135143248-175cc69d-b9c1-445a-8c25-3542a59d4bc9.png">
<img width="1389" alt="Screen Shot 2021-09-28 at 1 46 44 PM" src="https://user-images.githubusercontent.com/56391490/135143257-d01c8f89-30d9-4e26-8713-770278dc9d61.png">
<img width="1402" alt="Screen Shot 2021-09-28 at 1 47 17 PM" src="https://user-images.githubusercontent.com/56391490/135143269-89ed5528-f0df-468e-96ff-f926f66668bc.png">
<img width="1414" alt="Screen Shot 2021-09-28 at 1 47 54 PM" src="https://user-images.githubusercontent.com/56391490/135143283-210f4ea3-4b21-48b9-bae1-4ab5ca91bdf5.png">

**`geobubble`:**

https://chart-studio.plotly.com/~galvisgilberto/4570/earthquake-earthquake-and-landslide-landslide-meteorological-unknown-cause-volca/#/
https://chart-studio.plotly.com/~galvisgilberto/4572/earthquake-earthquake-and-landslide-landslide-meteorological-unknown-cause-volca/#/

<img width="1417" alt="Screen Shot 2021-09-28 at 1 50 15 PM" src="https://user-images.githubusercontent.com/56391490/135143410-4f5feacd-4250-4188-9b47-68c2a828dd76.png">
<img width="1418" alt="Screen Shot 2021-09-28 at 1 50 49 PM" src="https://user-images.githubusercontent.com/56391490/135143440-761500ea-04ea-405c-9be8-d3135f0b2714.png">
