### PR TITLE
fix issue when there is multiple legends

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -761,10 +761,14 @@ classdef plotlyfig < handle
             end
             
             % update legends
-            for n = 1:obj.State.Figure.NumLegends
-                if ~strcmpi(obj.PlotOptions.TreatAs, 'pie3')
-                    updateLegend(obj,n);
+            if obj.State.Figure.NumLegends < 2
+                for n = 1:obj.State.Figure.NumLegends
+                    if ~strcmpi(obj.PlotOptions.TreatAs, 'pie3')
+                        updateLegend(obj,n);
+                    end
                 end
+            else
+                updateLegendMultipleAxes(obj,1);
             end
             
             % update colorbars

--- a/plotly/plotlyfig_aux/core/updateLegendMultipleAxes.m
+++ b/plotly/plotlyfig_aux/core/updateLegendMultipleAxes.m
@@ -1,0 +1,127 @@
+function obj = updateLegendMultipleAxes(obj, legIndex)
+
+% x: ...[DONE]
+% y: ...[DONE]
+% traceorder: ...[DONE]
+% font: ...[DONE]
+% bgcolor: ...[DONE]
+% bordercolor: ...[DONE]
+% borderwidth: ...[DONE]
+% xref: ...[DONE]
+% yref: ...[DONE]
+% xanchor: ...[DONE]
+% yanchor: ...[DONE]
+
+%=========================================================================%
+%
+%-GET NECESSARY INFO FOR MULTIPLE LEGENDS-%
+%
+%=========================================================================%
+
+for traceIndex = 1:obj.State.Figure.NumPlots
+    allNames{traceIndex} = obj.data{traceIndex}.name;
+    allShowLegens(traceIndex) = obj.data{traceIndex}.showlegend;
+    obj.data{traceIndex}.showlegend = false;
+    obj.data{traceIndex}.legendgroup = obj.data{traceIndex}.name;
+
+    axIndex = obj.getAxisIndex(obj.State.Plot(traceIndex).AssociatedAxis);
+    [xSource, ySource] = findSourceAxis(obj, axIndex);
+    xAxis = eval(sprintf('obj.layout.xaxis%d', xSource));
+    yAxis = eval(sprintf('obj.layout.yaxis%d', xSource));
+
+    allDomain(traceIndex, 1) = max(xAxis.domain);
+    allDomain(traceIndex, 2) = max(yAxis.domain);
+end
+
+[~, groupIndex] = unique(allNames);
+
+for traceIndex = groupIndex'
+   obj.data{traceIndex}.showlegend = allShowLegens(traceIndex); 
+end
+
+%-------------------------------------------------------------------------%
+
+%-STANDARDIZE UNITS-%
+legendUnits = get(obj.State.Legend(legIndex).Handle,'Units');
+fontUnits = get(obj.State.Legend(legIndex).Handle,'FontUnits');
+set(obj.State.Legend(legIndex).Handle,'Units','normalized');
+set(obj.State.Legend(legIndex).Handle,'FontUnits','points');
+
+%-------------------------------------------------------------------------%
+
+%-LEGEND DATA STRUCTURE-%
+legendData = get(obj.State.Legend(legIndex).Handle);
+
+% only displays last legend as global Plotly legend
+obj.layout.legend = struct();
+
+%-------------------------------------------------------------------------%
+
+%-layout showlegend-%
+obj.layout.showlegend = strcmpi(legendData.Visible,'on');
+
+%-------------------------------------------------------------------------%
+
+%-legend (x,y) coordenates-%
+obj.layout.legend.x = 1.005 * max(allDomain(:,1));
+obj.layout.legend.y = 1.001 * max(allDomain(:,2));;
+
+%-legend (x,y) refs-%
+obj.layout.legend.xref = 'paper';
+obj.layout.legend.yref = 'paper';
+
+%-legend (x,y) anchors-%
+obj.layout.legend.xanchor = 'left';
+obj.layout.legend.yanchor = 'top';
+
+%-------------------------------------------------------------------------%
+
+if (strcmp(legendData.Box,'on') && strcmp(legendData.Visible, 'on'))
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend traceorder-%
+    obj.layout.legend.traceorder = 'normal';
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend borderwidth-%
+    obj.layout.legend.borderwidth = legendData.LineWidth;
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend bordercolor-%
+    col = 255*legendData.EdgeColor;
+    obj.layout.legend.bordercolor = sprintf('rgb(%f,%f,%f)', col);
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend bgcolor-%
+    col = 255*legendData.Color;
+    obj.layout.legend.bgcolor = sprintf('rgb(%f,%f,%f)', col);
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend font size-%
+    obj.layout.legend.font.size = legendData.FontSize;
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend font family-%
+    obj.layout.legend.font.family = matlab2plotlyfont(legendData.FontName);
+    
+    %---------------------------------------------------------------------%
+    
+    %-legend font colour-%
+    col = 255*legendData.TextColor;
+    obj.layout.legend.font.color = sprintf('rgb(%f,%f,%f)', col);
+    
+end
+
+%-------------------------------------------------------------------------%
+
+%-REVERT UNITS-%
+set(obj.State.Legend(legIndex).Handle,'Units',legendUnits);
+set(obj.State.Legend(legIndex).Handle,'FontUnits',fontUnits);
+
+end


### PR DESCRIPTION
**Case 1. When there is only one legend:**

In this case I just let the location of the Plotly legend be similar to the location of the Matlab legend. I attach an example screenshot.

<img width="1356" alt="Screen Shot 2021-09-29 at 1 53 02 PM" src="https://user-images.githubusercontent.com/56391490/135344033-8b4c5f1e-6efe-40f5-a4a0-4b91a6acddaa.png">

**Case 2: When there are multiple legends.**

Before making changes to the code, `fig2plotly` does the following (see screenshot). As we can see, the error appears because the philosophy of plotly for the legends is different from MATLAB. In MATLAB we can place a legend for each plot. While Plotly what it does is configure a single legend that handles the total group of plots.

So, the current `fig2plotly` code places the Plotly legend according to the first MATLAB legend and there it places the information for all MATLAB legends.

<img width="1330" alt="Screen Shot 2021-09-29 at 1 53 54 PM" src="https://user-images.githubusercontent.com/56391490/135343996-86020f92-7f1e-46a7-a06a-e9390a05ab2f.png">

**Updated code for this PR.**

To solve the issue with multiple legends, I have updated the `fig2plotly` code and now it does the following

<img width="1381" alt="Screen Shot 2021-09-29 at 2 04 27 PM" src="https://user-images.githubusercontent.com/56391490/135343954-7694626e-9e3b-407a-91f2-f6e943418e4f.png">

here is the link to Chart-Studio https://chart-studio.plotly.com/~galvisgilberto/4574/mahalanobis/#/

**Code example**

```
load fisheriris

rng('default') % for reproducibility
Y = tsne(meas,'Algorithm','exact','Distance','mahalanobis');
subplot(2,2,1)
gscatter(Y(:,1),Y(:,2),species)
title('Mahalanobis')

rng('default') % for fair comparison
Y = tsne(meas,'Algorithm','exact','Distance','cosine');
subplot(2,2,2)
gscatter(Y(:,1),Y(:,2),species)
title('Cosine')

rng('default') % for fair comparison
Y = tsne(meas,'Algorithm','exact','Distance','chebychev');
subplot(2,2,3)
gscatter(Y(:,1),Y(:,2),species)
title('Chebychev')

rng('default') % for fair comparison
Y = tsne(meas,'Algorithm','exact','Distance','euclidean');
subplot(2,2,4)
gscatter(Y(:,1),Y(:,2),species)
title('Euclidean')

fig2plotly(gcf, 'offline', false);
```
