### PR TITLE
fix issue #422

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -60,11 +60,10 @@ classdef plotlyfig < handle
             obj.PlotOptions.AspectRatio = [];
             obj.PlotOptions.CameraEye = [];
             obj.PlotOptions.is_headmap_axis = false;
-            obj.PlotOptions.Quality = -1;
-            obj.PlotOptions.Zmin = [];
             obj.PlotOptions.FrameDuration = 1;      % in ms.
             obj.PlotOptions.FrameTransitionDuration = 0;      % in ms.
             obj.PlotOptions.geoRenderType = 'geo';
+            obj.PlotOptions.DomainFactor = [1 1 1 1];
             
             % offline options
             obj.PlotOptions.Offline = true;
@@ -273,6 +272,10 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'geoRenderType'))
                             obj.PlotOptions.geoRenderType = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'DomainFactor'))
+                            len = length(varargin{a+1});
+                            obj.PlotOptions.DomainFactor(1:len) = varargin{a+1};
                         end
                     end
             end

--- a/plotly/plotlyfig_aux/core/updateAxis.m
+++ b/plotly/plotlyfig_aux/core/updateAxis.m
@@ -89,29 +89,21 @@ end
 
 %-------------------------------------------------------------------------%
 
-%-getting and setting postion data-%
-xo = axisData.Position(1);
-yo = axisData.Position(2);
-w = axisData.Position(3);
-h = axisData.Position(4);
-
-if obj.PlotOptions.AxisEqual
-    wh = min(axisData.Position(3:4));
-    w = wh;
-    h = wh;
-end
+%-get position data-%
+axisPos = axisData.Position .* obj.PlotOptions.DomainFactor;
+if obj.PlotOptions.AxisEqual, axisPos(3:4) = min(axisPos(3:4)); end
 
 %-------------------------------------------------------------------------%
 
 %-xaxis domain-%
-xaxis.domain = min([xo xo + w],1);
-scene.domain.x = min([xo xo + w],1);
+xaxis.domain = min([axisPos(1) sum(axisPos([1,3]))], 1);
+scene.domain.x = xaxis.domain;
 
 %-------------------------------------------------------------------------%
 
 %-yaxis domain-%
-yaxis.domain = min([yo yo + h],1);
-scene.domain.y = min([yo yo + h],1);
+yaxis.domain = min([axisPos(2) sum(axisPos([2,4]))], 1);
+scene.domain.y = yaxis.domain;
 
 %-------------------------------------------------------------------------%
 


### PR DESCRIPTION
This PR fix the [issue #422](https://github.com/plotly/plotly_matlab/issues/422)

To fix this I have proposed a new optional parameter called `'DomainFactor'`. This parameter scales each of the domain components of the plotly chart.

The domain or position of a chart box is defined by a 4-element vector, namely:

`domain = [xo, yo, w, h]`
where:
- `xo`: the initial x-coordinate of the chart (referred to the left-bottom)
- `yo`: the initial y-coordinate of the chart (referred to the left-bottom)
- `w`: is the width of the chart
- `h`: is the height of the chart

Then the `'DomainFactor'` parameter must be a vector of 4-elements at most, in which each of its elements will scale to each of the elements of the chart's domain.

## Example: Without scaling

```
rng('default')
X = rand(10,3);

tree = linkage(X,'average');

dendrogram(tree)

fig2plotly(gcf);
```

In this example we have not set the optional DomainFactor parameter, therefore, the domain of the chart will not be scaled, which will result in:

<img width="1564" alt="Screen Shot 2021-11-01 at 4 46 47 PM" src="https://user-images.githubusercontent.com/56391490/139740577-b4427654-1d16-48c8-9e9a-ae958a8a579a.png">

## Example: set DomianFactor to scaling

```
rng('default')
X = rand(10,3);

tree = linkage(X,'average');

dendrogram(tree)

domainFactor = [0.2, 1, 0.9, 0.9];
fig2plotly(gcf, 'offline', offline, 'DomainFactor', domainFactor);
```

In this case we have set the `'DomainFactor'` parameter as `[0.2, 1, 0.9, 0.9]` and like this:

- `xo` will be scaled by a factor of `0.2`
- `yo` will scale by a factor of `1` (it will stay the same)
- `w`: the width of the chart will be scaled by a factor of `0.9`
- `h`: the height of the chart will be scaled by a factor of `0.9`

Here I share the result:

<img width="1667" alt="Screen Shot 2021-11-01 at 4 47 26 PM" src="https://user-images.githubusercontent.com/56391490/139740607-62aa6b24-13a8-4a67-8b8a-b2d49b663afe.png">
