### PR TITLE
Add opacity on Matlab patch elements

### DIFF
--- a/plotly/plotlyfig_aux/helpers/extractPatchFace.m
+++ b/plotly/plotlyfig_aux/helpers/extractPatchFace.m
@@ -28,8 +28,11 @@ if isnumeric(patch_data.FaceColor)
     
     %-paper_bgcolor-%
     col = 255*patch_data.FaceColor;
-    marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
-    
+    if ~isempty(patch_data.FaceAlpha) && isnumeric(patch_data.FaceAlpha)
+        marker.color = ['rgba(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ',', num2str(patch_data.FaceAlpha), ')'];
+    else
+        marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+    end
 else
     switch patch_data.FaceColor
         


### PR DESCRIPTION
Currently, patch elements don't have any opacity. So, when using a patch with an alpha layer, it just appears as a plain color.
To fix this, I added a management of the alpha layer using _rgba_ instead of _rgb_ when it is available.

Example with a simple code using obw function (built-in function which add a patch on the frequency area containing 99% of signal energy).

```matlab
close all;
figure;
nSamp = 1024;
Fs = 1024e3;
SNR = 40;
rng default

t = (0:nSamp-1)'/Fs;

x = chirp(t,50e3,nSamp/Fs,100e3);
x = x+randn(size(x))*std(x)/db2mag(SNR);
obw(x, Fs);
title('test');
grid on;

p = fig2plotly;
```

Before :
![before](https://user-images.githubusercontent.com/7689997/147175896-0d4f7a86-4dc1-4dce-9cd8-7b284f44962b.png)

After :
![After](https://user-images.githubusercontent.com/7689997/147175900-3682ce89-a8dc-4dd6-baaf-e5400150b065.png)

