### PR TITLE
Add opacity on Matlab patch elements

### DIFF
--- a/plotly/plotlyfig_aux/helpers/extractPatchFace.m
+++ b/plotly/plotlyfig_aux/helpers/extractPatchFace.m
@@ -28,8 +28,11 @@ if isnumeric(patch_data.FaceColor)
     
     %-paper_bgcolor-%
     col = 255*patch_data.FaceColor;
-    marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
-    
+    if ~isempty(patch_data.FaceAlpha) && isnumeric(patch_data.FaceAlpha)
+        marker.color = ['rgba(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ',', num2str(patch_data.FaceAlpha), ')'];
+    else
+        marker.color = ['rgb(' num2str(col(1)) ',' num2str(col(2)) ',' num2str(col(3)) ')'];
+    end
 else
     switch patch_data.FaceColor
         


### PR DESCRIPTION
NOTE: I reopened the pull request after a fail in branch selection. Old one can be deleted

Currently, patch elements don't have any opacity. So, when using a patch with an alpha layer, it just appears as a plain color.
To fix this, I added a management of the alpha layer using rgba instead of rgb when it is available.

Example with a simple code using obw function (built-in function which add a patch on the frequency area containing 99% of signal energy).

```matlab
close all;
figure;
nSamp = 1024;
Fs = 1024e3;
SNR = 40;
rng default

t = (0:nSamp-1)'/Fs;

x = chirp(t,50e3,nSamp/Fs,100e3);
x = x+randn(size(x))*std(x)/db2mag(SNR);
obw(x, Fs);
title('test');
grid on;

p = fig2plotly;
```

Before :
![before](https://user-images.githubusercontent.com/7689997/147177195-f29a40a9-6bef-4a2d-a908-8d4661ffdfda.png)

After :
![After](https://user-images.githubusercontent.com/7689997/147177204-a0136e8d-a676-471e-8cc4-b8f6eaf272c8.png)

