### PR TITLE
fix  `nargin < 4` : figure without an extension

### DIFF
--- a/plotly/export_fig2/write_image.m
+++ b/plotly/export_fig2/write_image.m
@@ -15,6 +15,7 @@ elseif nargin < 3
     width=pfObj.layout.width;
     scale=1;
 elseif nargin < 4
+    filename=[filename,'.',char(imageFormat)];
     height=pfObj.layout.height;
     width=pfObj.layout.width;
     scale=1;


### PR DESCRIPTION
add the line code `filename=[filename,'.',char(imageFormat)];`